### PR TITLE
fix(call): set default evmc_result.gas_left to 0

### DIFF
--- a/c/polyjuice.h
+++ b/c/polyjuice.h
@@ -549,14 +549,15 @@ void selfdestruct(struct evmc_host_context* context,
 struct evmc_result call(struct evmc_host_context* context,
                         const struct evmc_message* msg) {
   ckb_debug("BEGIN call");
+  debug_print_int("msg.gas", msg->gas);
+  debug_print_int("msg.depth", msg->depth);
   debug_print_data("msg.input_data", msg->input_data, msg->input_size);
   debug_print_int("msg.kind", msg->kind);
   debug_print_data("call.sender", msg->sender.bytes, 20);
   debug_print_data("call.destination", msg->destination.bytes, 20);
   int ret;
   struct evmc_result res;
-  res.output_data = NULL;
-  res.output_size = 0;
+  memset(&res, 0, sizeof(res));
   res.release = release_result;
   gw_context_t* gw_ctx = context->gw_ctx;
 

--- a/polyjuice-tests/fuzz/Makefile
+++ b/polyjuice-tests/fuzz/Makefile
@@ -146,7 +146,7 @@ build/instruction_metrics.o: $(DEPS)/evmone/evmc/lib/instructions/instruction_me
 build/instruction_names.o: $(DEPS)/evmone/evmc/lib/instructions/instruction_names.c
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -c -o $@ $<
 build/instructions_calls.o: $(DEPS)/evmone/lib/evmone/instructions_calls.cpp
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -g -c -o $@ $<
 build/evmc_hex.o: $(DEPS)/evmone/evmc/lib/hex/hex.cpp
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -c -o $@ $<
 

--- a/polyjuice-tests/fuzz/polyjuice_generator_fuzzer.cc
+++ b/polyjuice-tests/fuzz/polyjuice_generator_fuzzer.cc
@@ -119,8 +119,8 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
       // reduce gas_limit to avoid timeout while fuzzing
       int64_t gas_limit;
       memcpy(&gas_limit, args_seg.ptr + 8, sizeof(int64_t));
+      dbg_print("gas_limit: %ld", gas_limit);
       if (gas_limit > 5500000) {
-        dbg_print("gas_limit: %ld", gas_limit);
         // The recommended gas limit in EIP-150 is 5.5 million.
         // (std::numeric_limits<int64_t>::max() >> 40) is close to 5.5 * 10^6
         // We make the max_gas_limit less than (std::numeric_limits<int64_t>::max() >> 38).


### PR DESCRIPTION
The default res.ges_left = 3980426352635039463 which will return to evmone when inner call is failed.

fix https://github.com/Flouse/godwoken-polyjuice/runs/3188815701?check_suite_focus=true#step:9:446