### PR TITLE
chore: add validation of sudt-erc20-proxy contract.bin checksum into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Rust components
-      run: rustup component add rustfmt && rustup component add clippy
+    - uses: actions/checkout@v2
+
     - uses: actions/cache@v2
       with:
         path: |
@@ -23,7 +22,18 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+    
+    - name: Install Rust components
+      run: rustup component add rustfmt && rustup component add clippy
     - name: Install moleculec
-      run: CARGO_TARGET_DIR=target/ cargo install moleculec --version 0.6.1
+      run: |
+        test "$(moleculec --version)" = "Moleculec 0.6.1" \
+        || CARGO_TARGET_DIR=target/ cargo install moleculec --version 0.6.1
+    - name: Install ckb-cli
+      run: CARGO_TARGET_DIR=target/ cargo install ckb-cli
+
+    - name: Validate the checksum of SudtERC20Proxy Contract.bin
+      run: make contract/sudt-erc20-proxy
+        
     - name: Run Integration-Test
       run: bash devtools/ci/integration-test.sh

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,18 @@ build/blockchain.h: build/blockchain.mol
 build/godwoken.h: build/godwoken.mol
 	${MOLC} --language c --schema-file $< > $@
 
+contract/sudt-erc20-proxy:
+	docker run --rm -v $$(pwd)/solidity/erc20:/contracts ethereum/solc:0.8.7 -o /contracts --bin --overwrite /contracts/SudtERC20Proxy_UserDefinedDecimals.sol
+	ERC20BIN_SHASUM="$$(ckb-cli util blake2b --binary-path solidity/erc20/ERC20.bin 2>&1 | head -n1)" && \
+	echo $$ERC20BIN_SHASUM && \
+	if [ "$$ERC20BIN_SHASUM" = "0xa63fcc117d9c73fcaaf65bd469e70bcfe5b3c46f61d1e7e13761c969fd261316" ]; \
+	then echo "ERC20BIN_SHASUM matches" ; \
+	else echo "ERC20BIN_SHASUM does not match" ; exit 1 ; fi
+# ERC20BIN_SHASUM="$$(shasum -a 256 solidity/erc20/ERC20.bin | cut -d' ' -f1)" && \
+# if [ "$$ERC20BIN_SHASUM" = "9f7bf1ab25b377ddc339e6de79a800d4c7dc83de7e12057a0129b467794ce3a3" ] ; \
+# then echo "ERC20BIN_SHASUM matches" ; \
+# else echo "ERC20BIN_SHASUM does not match" ; exit 1 ; fi
+
 fmt:
 	clang-format -i -style=Google c/**/*.*
 

--- a/devtools/ci/integration-test.sh
+++ b/devtools/ci/integration-test.sh
@@ -1,4 +1,3 @@
-
 set -x
 set -e
 

--- a/solidity/erc20/README.md
+++ b/solidity/erc20/README.md
@@ -5,8 +5,13 @@ Note: SudtERC20Proxy.sol will be deprecated.
 ## Compile Solidity Contract in ethereum/solc:0.8.7 docker image
 Here is the method that we compile SudtERC20Proxy_UserDefinedDecimals.sol.
 ```sh
-> docker run -v $(pwd):/contracts ethereum/solc:0.8.7 -o /contracts --abi --bin --overwrite /contracts/SudtERC20Proxy_UserDefinedDecimals.sol
+> docker run --rm -v $(pwd):/contracts ethereum/solc:0.8.7 -o /contracts --bin --overwrite /contracts/SudtERC20Proxy_UserDefinedDecimals.sol
 
+# checksum via ckb blake2b
+> ckb-cli util blake2b --binary-path ERC20.bin 2>&1 | head -n1
+0xa63fcc117d9c73fcaaf65bd469e70bcfe5b3c46f61d1e7e13761c969fd261316
+
+# checksum via sha256sum
 > sha256sum ERC20.bin 
 9f7bf1ab25b377ddc339e6de79a800d4c7dc83de7e12057a0129b467794ce3a3  ERC20.bin
 ```
@@ -17,8 +22,7 @@ The content of `SudtERC20Proxy_UserDefinedDecimals.ContractCode.hex` is copied f
 
 ```sh
 # Generate the contract code hash of SudtERC20Proxy_UserDefinedDecimals
-$ ckb-cli util blake2b --binary-hex [the content string of SudtERC20Proxy_UserDefinedDecimals.ContractCode.hex]
-
+> ckb-cli util blake2b --binary-hex [the content string of SudtERC20Proxy_UserDefinedDecimals.ContractCode.hex]
 0xa816b946a890cd593f780e8b6859a9b82314c5df4c8270d66f7c502e818345dc
 ```
 


### PR DESCRIPTION
1. add a command in Makefile to build the ERC20 contract via docker image.
2. add a command to verify the checksum of the binary using `blake2b`.

_Originally posted by @jjyr in https://github.com/nervosnetwork/godwoken-polyjuice/issues/83#issuecomment-914107279_