### PR TITLE
Fix memory leaks in bn256_pairing_istanbul()

### DIFF
--- a/c/contracts.h
+++ b/c/contracts.h
@@ -870,33 +870,7 @@ int bn256_pairing_istanbul(gw_context_t* ctx,
                            const uint8_t* input_src,
                            const size_t input_size,
                            uint8_t** output, size_t* output_size) {
-  if (input_size % 192 > 0) {
-    return ERROR_BN256_PAIRING;
-  }
-
-  int ret;
-  size_t length = input_size / 192;
-  /* G1[] */
-  intx::uint256 *cs = (intx::uint256 *)malloc(length * 4 * sizeof(intx::uint256));
-  if (cs == NULL) {
-    return FATAL_PRECOMPILED_CONTRACTS;
-  }
-  /* G2[] */
-  intx::uint256 *ts = (intx::uint256 *)malloc(length * 4 * sizeof(intx::uint256));
-  if (ts == NULL) {
-    return FATAL_PRECOMPILED_CONTRACTS;
-  }
-  for (size_t i = 0; i < input_size; i += 192) {
-    ret = parse_curve_point((void *)(cs + i / 192 * 4), (uint8_t *)input_src + i);
-    if (ret != 0) {
-      return ret;
-    }
-    ret = parse_twist_point((void *)(ts + i / 192 * 4), (uint8_t *)input_src + i + 64);
-    if (ret != 0) {
-      return ret;
-    }
-  }
-  ckb_debug("pairing is unsupported yet due to very high cycle cost!");
+  ckb_debug("bn256_pairing is unsupported yet due to very high cycle cost!");
   return ERROR_BN256_PAIRING;
 }
 


### PR DESCRIPTION
> pre-compiled contract `bn256_pairing` not supported yet,
due to its high cycle cost

bn256_pairing will not be implemented in the current Godwoken version.


## Error logs
```
=================================================================
==5875==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 188 byte(s) in 188 object(s) allocated from:
    #0 0x50a6dd in malloc /local/mnt/workspace/bcain_clang_bcain-ubuntu_7561/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x669086 in bn256_pairing_istanbul(gw_context_t*, unsigned char const*, unsigned long, bool, unsigned char const*, unsigned long, unsigned char**, unsigned long*) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../c/contracts.h:880:40
    #2 0x6727d2 in call(evmc_host_context*, evmc_message const*) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../c/polyjuice.h:579:11
    #3 0x71e106 in evmc::HostContext::call(evmc_message const&) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../deps/evmone/evmc/include/evmc/evmc.hpp:538:23
    #4 0x71e106 in evmc_status_code evmone::call<(evmc_call_kind)0, true>(evmone::ExecutionState&) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../deps/evmone/lib/evmone/instructions_calls.cpp:82:36

Direct leak of 188 byte(s) in 188 object(s) allocated from:
    #0 0x50a6dd in malloc /local/mnt/workspace/bcain_clang_bcain-ubuntu_7561/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x66909a in bn256_pairing_istanbul(gw_context_t*, unsigned char const*, unsigned long, bool, unsigned char const*, unsigned long, unsigned char**, unsigned long*) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../c/contracts.h:885:40
    #2 0x6727d2 in call(evmc_host_context*, evmc_message const*) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../c/polyjuice.h:579:11
    #3 0x71e106 in evmc::HostContext::call(evmc_message const&) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../deps/evmone/evmc/include/evmc/evmc.hpp:538:23
    #4 0x71e106 in evmc_status_code evmone::call<(evmc_call_kind)0, true>(evmone::ExecutionState&) /home/runner/work/godwoken-polyjuice/godwoken-polyjuice/polyjuice-tests/fuzz/../../deps/evmone/lib/evmone/instructions_calls.cpp:82:36

SUMMARY: AddressSanitizer: 376 byte(s) leaked in 376 allocation(s).
```
> https://github.com/Flouse/godwoken-polyjuice/runs/3558380331?check_suite_focus=true#step:11:974

