### PR TITLE
docs: comparison with EVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 # Godwoken polyjuice
 An Ethereum compatible backend for [Godwoken](https://github.com/nervosnetwork/godwoken) rollup framework. It include generator and validator implementations.
 
+Polyjuice provides an [Ethereum](https://ethereum.org/en/) compatible layer on [Nervos CKB](https://github.com/nervosnetwork/ckb). It leverages account model as well as scalability provided by [Godwoken](./life_of_a_godwoken_transaction.md), then integrates [evmone](https://github.com/ethereum/evmone) as an EVM engine for running Ethereum smart contracts.
+
+Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. See [EVM-compatible.md](docs/EVM-compatible.md) and [Addition-Features.md](docs/Addition-Features.md) for more details.
+
 ### Features
-- [x] All op codes
+- [x] All [Ethereum Virtual Machine Opcodes](https://ethervm.io/)
 - [x] Value transfer
 - [ ] pre-compiled contracts
   + [x] ecrecover
@@ -96,3 +100,5 @@ short_address = blake2b(script.as_slice())[0..20]
 ## More docs
 * [EVM compatible](docs/EVM-compatible.md)
 * [Addition Features](docs/Addition-Features.md)
+* [Life of a Polyjuice Transaction](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_polyjuice_transaction.md)
+* [Life of a Godwoken Transaction](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_godwoken_transaction.md)

--- a/docs/EVM-compatible.md
+++ b/docs/EVM-compatible.md
@@ -1,4 +1,4 @@
-## Comarison with EVM
+## Comparison with EVM
 Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. But in the current version, something is incompatible with EVM.
 
 ### pETH

--- a/docs/EVM-compatible.md
+++ b/docs/EVM-compatible.md
@@ -1,11 +1,32 @@
-## Things don't compatible with EVM
+## Comarison with EVM
+Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. But in the current version, something is incompatible with EVM.
 
-* Transfer value can not exceed u128
-* All address(EoA/contract) format are godwoken short address
-* Create contract account returns godwoken short address
+### pETH
+**pETH** is a new concept introduced by Polyjuice. 
+
+Recall that in Ethereum, the gas of each smart contract is calculated. The transaction fee is calculated then by multiplying gas with specified gas price. In Polyjuice, **pETH** is used as the unit for calculating transaction fees. This means while the gas price in Ethereum is ETH/gas(which is denominated in wei, which is 1e-18 ether), in Polyjuice gas price is measured in pETH/gas. When executing a transaction, Polyjuice will deduct transaction fees using tokens in the layer 2 sUDT type denoted by **pETH**.
+
+Note in Ethereum, one can also send some ETH to a smart contract for certain behavior. In Polyjuice, this feature is also performed by sending pETH.
+
+### Account Abstraction
+Polyjuice only provides [contract accounts](https://ethereum.org/en/glossary/#contract-account). Godwoken's user accounts are leveraged to act as [EoAs](https://ethereum.org/en/glossary/#eoa).
+
+#### Different Address Type: 
+* All eth_address(EoA/contract) format are `short_godwoken_account_script_hash`, which is the 20 bytes prefix of Godwoken account script hash
+* Creating a contract account returns `short_godwoken_account_script_hash`
+
+When you pass some [address-type](https://docs.soliditylang.org/en/v0.8.9/types.html#address) parameters to call smart-contract, the `address` converting must be done first, vice versa for the return `address` value. [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider) has been designed to handle these conversion tasks. It converts `address` type converting according to your contract's ABI. 
+
+### Transaction Structure
+A Polyjuice transaction is essentially just a godwoken transaction, since Polyjuice is the main [backend of Godwoken](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_godwoken_transaction.md#backend) for state computation.
+
+When you send an ethereum transaction to Godwoken-Polyjuice, the data structure of this very transaction needs to be converted to godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/9a3d92/crates/types/schemas/godwoken.mol#L56-L61) type. Also [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider) has been designed to handle it.
+
+### Others
+* The `transfer value` can not exceed uint128:MAX
 * transaction context
-  - chain id is creator account id
+  - chain_id is creator_account_id
   - block gas limit is `12500000`, and is not block level limit, every transaction can reach the limit
   - block difficulty is `2500000000000000`
 * pre-compiled contract
-  - `bn256_pairing` not supported yet，due to too high cycle cost (WIP) 
+  - `bn256_pairing` is not supported yet，due to too high cycle cost (WIP) 

--- a/docs/EVM-compatible.md
+++ b/docs/EVM-compatible.md
@@ -23,9 +23,9 @@ When you pass some [address-type](https://docs.soliditylang.org/en/v0.8.9/types.
 
 ## Transaction Structure
 
-A Polyjuice transaction is essentially just a godwoken transaction, since Polyjuice is the main [backend of Godwoken](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_godwoken_transaction.md#backend) for state computation.
+A Polyjuice transaction is essentially just a Godwoken transaction.
 
-When you send an ethereum transaction to Godwoken-Polyjuice, the data structure of this very transaction needs to be converted to godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/9a3d92/crates/types/schemas/godwoken.mol#L56-L61) type. Also [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider) has been designed to handle it.
+When you send an ethereum transaction, the transaction is converted to Godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/9a3d92/crates/types/schemas/godwoken.mol#L56-L61) type which is automatically handled by [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider).
 
 ## Behavioral differences of some opcodes
 

--- a/docs/EVM-compatible.md
+++ b/docs/EVM-compatible.md
@@ -1,32 +1,48 @@
-## Comparison with EVM
+# Comparison with EVM
+
 Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. But in the current version, something is incompatible with EVM.
 
-### pETH
-**pETH** is a new concept introduced by Polyjuice. 
+## pETH
+
+**pETH** is a new concept introduced by Polyjuice.
 
 Recall that in Ethereum, the gas of each smart contract is calculated. The transaction fee is calculated then by multiplying gas with specified gas price. In Polyjuice, **pETH** is used as the unit for calculating transaction fees. This means while the gas price in Ethereum is ETH/gas(which is denominated in wei, which is 1e-18 ether), in Polyjuice gas price is measured in pETH/gas. When executing a transaction, Polyjuice will deduct transaction fees using tokens in the layer 2 sUDT type denoted by **pETH**.
 
 Note in Ethereum, one can also send some ETH to a smart contract for certain behavior. In Polyjuice, this feature is also performed by sending pETH.
 
-### Account Abstraction
+## Account Abstraction
+
 Polyjuice only provides [contract accounts](https://ethereum.org/en/glossary/#contract-account). Godwoken's user accounts are leveraged to act as [EoAs](https://ethereum.org/en/glossary/#eoa).
 
-#### Different Address Type: 
+### Different Address Type
+
 * All eth_address(EoA/contract) format are `short_godwoken_account_script_hash`, which is the 20 bytes prefix of Godwoken account script hash
 * Creating a contract account returns `short_godwoken_account_script_hash`
 
-When you pass some [address-type](https://docs.soliditylang.org/en/v0.8.9/types.html#address) parameters to call smart-contract, the `address` converting must be done first, vice versa for the return `address` value. [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider) has been designed to handle these conversion tasks. It converts `address` type converting according to your contract's ABI. 
+When you pass some [address-type](https://docs.soliditylang.org/en/v0.8.9/types.html#address) parameters to call smart-contract, the `address` converting must be done first, vice versa for the return `address` value. [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider) has been designed to handle these conversion tasks. It converts `address` type converting according to your contract's ABI.
 
-### Transaction Structure
+## Transaction Structure
+
 A Polyjuice transaction is essentially just a godwoken transaction, since Polyjuice is the main [backend of Godwoken](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_godwoken_transaction.md#backend) for state computation.
 
 When you send an ethereum transaction to Godwoken-Polyjuice, the data structure of this very transaction needs to be converted to godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/9a3d92/crates/types/schemas/godwoken.mol#L56-L61) type. Also [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider) has been designed to handle it.
 
-### Others
-* The `transfer value` can not exceed uint128:MAX
+## Behavioral differences of some opcodes
+
+| EVM Opcode | Solidity Usage | Behavior in Polyjuice | Behavior in EVM |
+| - | - | - | - |
+| COINBASE | `block.coinbase` | address of the block_producer | address of the current block's miner |
+| CHAINID | `chain_id()` | creator_account_id | Istanbul hardfork, EIP-1344: current network's chain id |
+| GASLIMIT | `block.gaslimit` | 12,500,000 | current block's gas limit |
+| DIFFICULTY | `block.difficulty` | 2,500,000,000,000,000 | current block's difficulty |
+
+## Others
+
 * transaction context
-  - chain_id is creator_account_id
-  - block gas limit is `12500000`, and is not block level limit, every transaction can reach the limit
-  - block difficulty is `2500000000000000`
+  * chain_id is [creator_account_id](https://github.com/nervosnetwork/godwoken/blob/5735d8f/docs/life_of_a_polyjuice_transaction.md#root-account--deployment)
+  * block gas limit is `12500000`, and is not block level limit, every transaction can reach the limit
+  * block difficulty is always `2500000000000000`
+* The `transfer value` can not exceed uint128:MAX
 * pre-compiled contract
-  - `bn256_pairing` is not supported yet，due to too high cycle cost (WIP) 
+  * `bn256_pairing` is not supported yet，due to too high cycle cost (WIP)
+  * [addition pre-compiled contracts](Addition-Features.md)


### PR DESCRIPTION
## Comparison with EVM
Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. But in the current version, something is incompatible with EVM.

This PR adds more docs about EVM compatibility. See [EVM-compatible.md](https://github.com/nervosnetwork/godwoken-polyjuice/docs/EVM-compatible.md) and [Addition-Features.md](https://github.com/nervosnetwork/godwoken-polyjuice/docs/Addition-Features.md) for more details.
