### PR TITLE
Interoperability: support new L2TX format with native `eth_address`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,13 @@ log-version-via-docker: generate-protocol
 	mkdir -p build
 	docker run --rm -v `pwd`:/code -w /code ${BUILDER_DOCKER} bash -c "make build/generator_log && make build/validator_log"
 
-# Be aware that a given prerequisite will only be built once per invocation of make, at most.
-all-in-debug-mode: LDFLAGS := -g
-all-in-debug-mode: $(ALL_OBJS) build/generator_log build/validator_log
-
 all-via-docker-in-debug-mode: generate-protocol
 	docker run --rm -v `pwd`:/code -w /code ${BUILDER_DOCKER} make all-in-debug-mode
-debug-all: CFLAGS += -DCKB_C_STDLIB_PRINTF -O0
-debug-all: all
+# Be aware that a given prerequisite will only be built once per invocation of make, at most.
+# all-in-debug-mode: LDFLAGS := -g
+all-in-debug-mode: CFLAGS += -DCKB_C_STDLIB_PRINTF -O0
+all-in-debug-mode: all
+
 
 clean-via-docker:
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ VALIDATOR_DEPS := c/validator/secp256k1_helper.h $(BIN_DEPS)
 # BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:aae8a3f79705f67d505d1f1d5ddc694a4fd537ed1c7e9622420a470d59ba2ec3
 # docker pull nervos/ckb-riscv-gnu-toolchain:bionic-20190702
 BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:7b168b4b109a0f741078a71b7c4dddaf1d283a5244608f7851f5714fbad273ba
-# BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain:bionic-20190702-newlib-debug-symbols
+# TODO: update to BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain:bionic-20190702-newlib-debug-symbols
 
 all: build/test_contracts build/test_rlp build/generator build/validator build/generator_log build/validator_log build/test_ripemd160 build/blockchain.h build/godwoken.h build/eth-addr-reg-generator build/eth-addr-reg-validator
 
@@ -67,7 +67,6 @@ all-via-docker-in-debug-mode: generate-protocol
 # all-in-debug-mode: LDFLAGS := -g
 all-in-debug-mode: CFLAGS += -DCKB_C_STDLIB_PRINTF -O0
 all-in-debug-mode: all
-
 
 clean-via-docker:
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ VALIDATOR_DEPS := c/validator/secp256k1_helper.h $(BIN_DEPS)
 BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain@sha256:7b168b4b109a0f741078a71b7c4dddaf1d283a5244608f7851f5714fbad273ba
 # TODO: update to BUILDER_DOCKER := nervos/ckb-riscv-gnu-toolchain:bionic-20190702-newlib-debug-symbols
 
-all: build/test_contracts build/test_rlp build/generator build/validator build/generator_log build/validator_log build/test_ripemd160 build/blockchain.h build/godwoken.h build/eth-addr-reg-generator build/eth-addr-reg-validator
+all: build/test_contracts build/test_rlp build/generator build/validator build/generator_log build/validator_log build/test_ripemd160 build/blockchain.h build/godwoken.h build/eth_addr_reg_generator build/eth_addr_reg_validator
 
 all-via-docker: generate-protocol
 	mkdir -p build
@@ -64,8 +64,8 @@ log-version-via-docker: generate-protocol
 all-via-docker-in-debug-mode: generate-protocol
 	docker run --rm -v `pwd`:/code -w /code ${BUILDER_DOCKER} make all-in-debug-mode
 # Be aware that a given prerequisite will only be built once per invocation of make, at most.
-# all-in-debug-mode: LDFLAGS := -g
-all-in-debug-mode: CFLAGS += -DCKB_C_STDLIB_PRINTF -O0
+all-in-debug-mode: LDFLAGS := -g # only use -O0 to decrease compile time while coding and debugging
+all-in-debug-mode: CFLAGS += -DCKB_C_STDLIB_PRINTF
 all-in-debug-mode: all
 
 clean-via-docker:
@@ -104,12 +104,12 @@ build/validator_log: c/validator.c $(VALIDATOR_DEPS)
 	$(OBJCOPY) --strip-debug --strip-all $@
 	cd $(SECP_DIR) && (git apply -R workaround-fix-g++-linking.patch || true) && cd - # revert patch
 
-build/eth-addr-reg-generator: c/eth_addr_reg.c
+build/eth_addr_reg_generator: c/eth_addr_reg.c
 	$(CC) $(CFLAGS) $(GENERATOR_FLAGS) $(LDFLAGS) -Ibuild -o $@ $<
 	$(OBJCOPY) --only-keep-debug $@ $@.debug
 	$(OBJCOPY) --strip-debug --strip-all $@
 
-build/eth-addr-reg-validator: c/eth_addr_reg.c
+build/eth_addr_reg_validator: c/eth_addr_reg.c
 	$(CC) $(CFLAGS) $(VALIDATOR_FLAGS) $(LDFLAGS) -Ibuild -o $@ $<
 	$(OBJCOPY) --only-keep-debug $@ $@.debug
 	$(OBJCOPY) --strip-debug --strip-all $@

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-# Godwoken polyjuice
+# Godwoken Polyjuice
 An Ethereum compatible backend for [Godwoken](https://github.com/nervosnetwork/godwoken) rollup framework. It include generator and validator implementations.
 
 Polyjuice provides an [Ethereum](https://ethereum.org/en/) compatible layer on [Nervos CKB](https://github.com/nervosnetwork/ckb). It leverages account model as well as scalability provided by [Godwoken](./life_of_a_godwoken_transaction.md), then integrates [evmone](https://github.com/ethereum/evmone) as an EVM engine for running Ethereum smart contracts.
 
 Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. See [EVM-compatible.md](docs/EVM-compatible.md) and [Addition-Features.md](docs/Addition-Features.md) for more details.
 
-### Features
+## Features
 - [x] All [Ethereum Virtual Machine Opcodes](https://ethervm.io/)
 - [x] Value transfer
 - [ ] pre-compiled contracts
@@ -25,10 +25,7 @@ Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support a
 
 ### Polyjuice arguments
 ```
-header     : [u8; 8]  (header[0]    = 0xff, 
-                       header[1]    = 0xff, 
-                       header[2]    = 0xff, 
-                       header[3..7] = "POLY"
+header     : [u8; 8]  (header[0..7] = "ETHPOLY",
                        header[7]    = call_kind { 0: CALL, 3: CREATE })
 gas_limit  : u64      (little endian)
 gas_price  : u128     (little endian)
@@ -37,19 +34,19 @@ input_size : u32      (little endian)
 input_data : [u8; input_size]   (input data)
 ```
 
-Every polyjuice argument fields must been serialized one by one and put into godwoken [`RawL2Transaction.args`][rawl2tx-args] for polyjuice to read. If the `input_data` have 56 bytes, then the serialized data size is `8 + 8 + 16 + 16 + 4 + 56 = 108` bytes.
+Every Polyjuice argument fields must been serialized one by one and put into godwoken [`RawL2Transaction.args`][rawl2tx-args] for polyjuice to read. If the `input_data` have 56 bytes, then the serialized data size is `8 + 8 + 16 + 16 + 4 + 56 = 108` bytes.
 
 
 ### Creator account script
 ```
-code_hash: polyjuice_validator_type_script_hash
+code_hash: Polyjuice_validator_type_script_hash
 hash_type: type
 args:
     rollup_type_hash : [u8; 32]
     sudt_id          : u32          (little endian, the token id)
 ```
 
-Polyjuice creator account is a godwoken account for creating polyjuice contract account. This account can only been created by [meta contract][meta-contract], and the account id is used as the chain id in polyjuice. The `sudt_id` field in script args is the sudt token current polyjuice instance bind to.
+Polyjuice creator account is a godwoken account for creating Polyjuice contract account. This account can only been created by [meta contract][meta-contract], and the account id is used as the chain id in Polyjuice. The `sudt_id` field in script args is the sudt token current Polyjuice instance bind to.
 
 ### Contract account script
 
@@ -64,6 +61,7 @@ args:
 ```
 
 #### Normal contract account script
+The Polyjuice contract account created in Polyjuice by `CREATE` call kind or Opcode.
 ```
 info_content:
     sender_address  : [u8; 20]   (the msg.sender: blake128(sender_script) + account id)
@@ -72,9 +70,8 @@ info_content:
 info_data: rlp_encode(sender_address, sender_nonce)
 ```
 
-The polyjuice contract account created in polyjuice by `CREATE` call kind or op code.
-
 #### Create2 contract account script
+The Polyjuice contract account created in Polyjuice by `CREATE2` Opcode.
 ```
 info_data:
     special_byte    : u8         (value is '0xff', refer to ethereum)
@@ -83,19 +80,22 @@ info_data:
     init_code_hash  : [u8; 32]   (keccak256(init_code))
 ```
 
-The polyjuice contract account created in polyjuice by `CREATE2` op code.
+### Address used in Polyjuice
+In the latest version of Polyjuice, the [EOA](https://ethereum.org/en/glossary/#eoa) addresses are native `eth_address`, which is the rightmost 160 bits of a Keccak hash of an ECDSA public key.
 
-### Address used in polyjuice
-
-The address used in polyjuice are all godwoken short address, which is:
-
+In the previous version of Polyjuice, all the addresses are `short_godwoken_account_script_hash`, which is:
 ``` rust
-short_address = blake2b(script.as_slice())[0..20]
+short_godwoken_account_script_hash = blake2b(script.as_slice())[0..20]
 ```
 
+| polyjuice_args_header | EOA address type |
+| - | - |
+| `header[0..7] = "ETHPOLY"` | native `eth_address` |
+| `header[0] = 0xff,`<br>`header[1] = 0xff,`<br>`header[2] = 0xff,`<br>`header[3..7] = "POLY"`| short_godwoken_account_script_hash |
 
-[rawl2tx-args]: https://github.com/nervosnetwork/godwoken/blob/26d15dbe42d15ad902593fcc89cf82b1ccc18d66/crates/types/schemas/godwoken.mol#L50
-[meta-contract]: https://github.com/nervosnetwork/godwoken-scripts/blob/32f98ac2ce1ab416cb4ffa143ec1f5ba3ddce51f/c/contracts/meta_contract.c
+
+[rawl2tx-args]: https://github.com/nervosnetwork/godwoken/blob/9a3d921/crates/types/schemas/godwoken.mol#L60
+[meta-contract]: https://github.com/nervosnetwork/godwoken-scripts/blob/028dbc4/c/contracts/meta_contract.c
 
 ## More docs
 * [EVM compatible](docs/EVM-compatible.md)

--- a/c/eth_addr_reg.c
+++ b/c/eth_addr_reg.c
@@ -29,6 +29,7 @@ int printf(const char *format, ...) {
 /* MSG_TYPE */
 #define MSG_QUERY_GW_BY_ETH 0
 #define MSG_QUERY_ETH_BY_GW 1
+#define MSG_SET_MAPPING     2
 
 int main() {
 #ifndef NO_DEBUG_LOG
@@ -83,6 +84,15 @@ int main() {
       return ret;
     }
     ret = ctx.sys_set_program_return_data(&ctx, eth_address, ETH_ADDRESS_LEN);
+    if (ret != 0) {
+      return ret;
+    }
+  }
+  else if (msg.item_id == MSG_SET_MAPPING) {
+    mol_seg_t eth_address_seg = MolReader_SetMapping_get_eth_address(&msg.seg);
+    mol_seg_t script_hash_seg = MolReader_SetMapping_get_gw_script_hash(&msg.seg);
+    ret = update_eth_address_registry(&ctx,
+                                      eth_address_seg.ptr, script_hash_seg.ptr);
     if (ret != 0) {
       return ret;
     }

--- a/c/other_contracts.h
+++ b/c/other_contracts.h
@@ -3,7 +3,6 @@
 #define OTHER_CONTRACTS_H_
 
 #include "polyjuice_utils.h"
-#include "polyjuice_globals.h"
 
 /* Gas fee */
 #define RECOVER_ACCOUNT_GAS 3600 /* more than ecrecover */
@@ -91,7 +90,7 @@ int eth_to_godwoken_addr_gas(const uint8_t* input_src,
    input[12..32] => ETH address
 
  output:
-   output[12..32] => godwoken short address
+   output[12..32] => short_gw_script_hash, a.k.a. godwoken short address
  */
 int eth_to_godwoken_addr(gw_context_t* ctx,
                          const uint8_t* code_data,
@@ -111,13 +110,13 @@ int eth_to_godwoken_addr(gw_context_t* ctx,
     }
   }
   int ret;
-  uint8_t script_args[SCRIPT_ARGS_LEN];
+  uint8_t script_args[CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN];
   memcpy(script_args, g_rollup_script_hash, 32);
   memcpy(script_args + 32, (uint8_t*)(&g_creator_account_id), 4);
   memcpy(script_args + 32 + 4, input_src + 12, 20);
   mol_seg_t new_script_seg;
   ret = build_script(g_script_code_hash, g_script_hash_type, script_args,
-                     SCRIPT_ARGS_LEN, &new_script_seg);
+                     CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN, &new_script_seg);
   if (ret != 0) {
     return ret;
   }

--- a/c/polyjuice.h
+++ b/c/polyjuice.h
@@ -30,7 +30,6 @@ int printf(const char *format, ...) {
 #include "common.h"
 
 #include "sudt_utils.h"
-#include "polyjuice_globals.h"
 #include "polyjuice_errors.h"
 #include "polyjuice_utils.h"
 
@@ -274,7 +273,7 @@ int load_account_code(gw_context_t* gw_ctx, uint32_t account_id,
   mol_seg_t hash_type_seg = MolReader_Script_get_hash_type(&script_seg);
   mol_seg_t args_seg = MolReader_Script_get_args(&script_seg);
   mol_seg_t raw_args_seg = MolReader_Bytes_raw_bytes(&args_seg);
-  if (raw_args_seg.size != CONTRACT_ACCOUNT_SCRIPT_ARGS_SIZE) {
+  if (raw_args_seg.size != CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN) {
     debug_print_int("[load_account_code] invalid account script", account_id);
     debug_print_int("[load_account_code] raw_args_seg.size", raw_args_seg.size);
     // This is an EoA or other kind of account
@@ -811,7 +810,7 @@ int load_globals(gw_context_t* ctx, uint32_t to_id, evmc_call_kind call_kind) {
     /* polyjuice creator account */
     g_creator_account_id = to_id;
     creator_raw_args_seg = raw_args_seg;
-  } else if (raw_args_seg.size == CONTRACT_ACCOUNT_SCRIPT_ARGS_SIZE) {
+  } else if (raw_args_seg.size == CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN) {
     /* read creator account id and do some checking */
     memcpy(&g_creator_account_id, raw_args_seg.ptr + 32, sizeof(uint32_t));
     int ret = load_account_script(ctx,
@@ -858,7 +857,7 @@ int create_new_account(gw_context_t* ctx,
   }
 
   int ret = 0;
-  uint8_t script_args[SCRIPT_ARGS_LEN];
+  uint8_t script_args[CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN];
   uint8_t data[128] = {0};
   uint32_t data_len = 0;
   if (msg->kind == EVMC_CREATE) {
@@ -913,7 +912,7 @@ int create_new_account(gw_context_t* ctx,
   mol_seg_t new_script_seg;
   uint32_t new_account_id;
   ret = build_script(g_script_code_hash, g_script_hash_type, script_args,
-                     SCRIPT_ARGS_LEN, &new_script_seg);
+                     CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN, &new_script_seg);
   if (ret != 0) {
     return ret;
   }

--- a/c/polyjuice.mol
+++ b/c/polyjuice.mol
@@ -13,7 +13,5 @@ struct EthToGw {
 
 struct GwToEth {
     gw_script_hash: Byte32,
-    // TODO: should we use gw_short_script_hash?
-    // a.k.a. godwoken short address (script_hash[0..n])
 }
 // --- end of ETH Address Registry ---

--- a/c/polyjuice.mol
+++ b/c/polyjuice.mol
@@ -1,10 +1,11 @@
 // --- ETH Address Registry ---
+
 array Byte20 [byte; 20];
-// option ETHAddrOpt (Byte20);
 
 union ETHAddrRegArgs {
     EthToGw,
     GwToEth,
+    SetMapping,
 }
 
 struct EthToGw {
@@ -12,6 +13,11 @@ struct EthToGw {
 }
 
 struct GwToEth {
+    gw_script_hash: Byte32,
+}
+
+struct SetMapping {
+    eth_address: Byte20,
     gw_script_hash: Byte32,
 }
 // --- end of ETH Address Registry ---

--- a/c/polyjuice_globals.h
+++ b/c/polyjuice_globals.h
@@ -1,24 +1,29 @@
 #ifndef POLYJUICE_GLOBALS_H
 #define POLYJUICE_GLOBALS_H
 
-#define POLYJUICE_VERSION "v0.8.9"
+#define POLYJUICE_VERSION "v0.9.0"
 #define POLYJUICE_SHORT_ADDR_LEN 20
-/* 32 + 4 + 20 */
-#define SCRIPT_ARGS_LEN 56
+
+/** Polyjuice contract account (normal/create2) script args size */
+#define CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN 56       /* 32 + 4 + 20 */
 
 static uint8_t g_rollup_script_hash[32] = {0};
 static uint32_t g_sudt_id = UINT32_MAX;
 
 static bool g_is_using_native_eth_address = false;
 /** 
- * Receipt.contractAddress
- * The contract address created, if the transaction was a contract creation,
- * otherwise null
+ * Receipt.contractAddress is the created contract,
+ * if the transaction was a contract creation, otherwise null
  */
-static uint32_t g_created_id = UINT32_MAX;
 static uint8_t g_created_address[20] = {0};
+static uint32_t g_created_id = UINT32_MAX;
 
+/**
+ * creator_account, known as root account
+ * see also: https://github.com/nervosnetwork/godwoken/blob/5735d8f/docs/life_of_a_polyjuice_transaction.md#root-account--deployment
+ */
 static uint32_t g_creator_account_id = UINT32_MAX;
+
 static evmc_address g_tx_origin = {0};
 
 static uint8_t g_script_code_hash[32] = {0};

--- a/c/polyjuice_utils.h
+++ b/c/polyjuice_utils.h
@@ -7,6 +7,7 @@
 
 #include <evmc/evmc.h>
 #include "ckb_syscalls.h"
+#include "polyjuice_globals.h"
 #include "polyjuice_errors.h"
 
 #define ETH_ADDRESS_LEN 20
@@ -49,9 +50,6 @@ void debug_print_int(const char* prefix, int64_t ret) {
 #endif /* NO_DEBUG_LOG */
 
 #define memset(dest, c, n) _smt_fast_memset(dest, c, n)
-
-/* polyjuice contract account (normal/create2) script args size*/
-static const uint32_t CONTRACT_ACCOUNT_SCRIPT_ARGS_SIZE = 32 + 4 + 20;
 
 int build_script(const uint8_t code_hash[32], const uint8_t hash_type,
                  const uint8_t* args, const uint32_t args_len,

--- a/c/polyjuice_utils.h
+++ b/c/polyjuice_utils.h
@@ -156,12 +156,11 @@ int load_script_hash_by_eth_address(gw_context_t *ctx,
   if (_is_zero_hash(script_hash)) {
     return GW_ERROR_NOT_FOUND;
   }
+
+  // TODO: cache [eth_address <=> script_hash] mapping data here
   return 0;
 }
 
-/**
- * @param script_hash should have been initialed as zero_hash = {0}
- */
 int load_eth_address_by_script_hash(gw_context_t *ctx,
                                     uint8_t script_hash[GW_KEY_BYTES],
                                     uint8_t eth_address[ETH_ADDRESS_LEN]) {
@@ -182,8 +181,7 @@ int load_eth_address_by_script_hash(gw_context_t *ctx,
   if (ret != 0) {
     return ret;
   }
-  if (_is_zero_hash(script_hash)) {
-    // TODO: check not found situation
+  if (_is_zero_hash(value)) {
     return GW_ERROR_NOT_FOUND;
   }
 
@@ -194,6 +192,9 @@ int load_eth_address_by_script_hash(gw_context_t *ctx,
 // int load_account_id_by_eth_address(gw_context_t *ctx,
 //                               const uint8_t address[20],
 //                               uint32_t *account_id) {
+//   if (ctx == NULL) {
+//     return GW_FATAL_INVALID_CONTEXT;
+//   }
 //   uint8_t script_hash[32] = {0};
 //   int ret = load_script_hash_by_eth_address(ctx, address, script_hash);
 //   if (ret != 0) {

--- a/c/polyjuice_utils.h
+++ b/c/polyjuice_utils.h
@@ -100,7 +100,8 @@ int short_script_hash_to_account_id(gw_context_t *ctx,
                                     const uint8_t address[20],
                                     uint32_t *account_id) {
   uint8_t script_hash[32] = {0};
-  int ret = ctx->sys_get_script_hash_by_prefix(ctx, (uint8_t *)address, 20, script_hash);
+  int ret = ctx->sys_get_script_hash_by_prefix(ctx, (uint8_t *)address, 20,
+                                               script_hash);
   if (ret != 0) {
     return ret;
   }
@@ -120,7 +121,7 @@ void gw_build_script_hash_to_eth_address_key(uint8_t script_hash[GW_KEY_BYTES],
 }
 
 void gw_build_eth_address_to_script_hash_key(
-    uint8_t eth_address[ETH_ADDRESS_LEN], uint8_t raw_key[GW_KEY_BYTES]) {
+    const uint8_t eth_address[ETH_ADDRESS_LEN], uint8_t raw_key[GW_KEY_BYTES]) {
   blake2b_state blake2b_ctx;
   blake2b_init(&blake2b_ctx, GW_KEY_BYTES);
   /* placeholder: 0 */
@@ -138,7 +139,7 @@ void gw_build_eth_address_to_script_hash_key(
  * @param script_hash should have been initialed as zero_hash = {0}
  */
 int load_script_hash_by_eth_address(gw_context_t *ctx,
-                                    uint8_t eth_address[ETH_ADDRESS_LEN],
+                                    const uint8_t eth_address[ETH_ADDRESS_LEN],
                                     uint8_t script_hash[GW_VALUE_BYTES]) {
   if (ctx == NULL) {
     return GW_FATAL_INVALID_CONTEXT;
@@ -174,7 +175,7 @@ int load_eth_address_by_script_hash(gw_context_t *ctx,
   /** 
    * ethabi address format
    *  e.g. web3.eth.abi.decodeParameter('address',
-   *          '0000000000000000000000001829d79cce6aa43d13e67216b355e81a7fffb220')
+   *         '0000000000000000000000001829d79cce6aa43d13e67216b355e81a7fffb220')
    */
   uint8_t value[GW_VALUE_BYTES] = {0};
   int ret = ctx->_internal_load_raw(ctx, raw_key, value);
@@ -189,6 +190,18 @@ int load_eth_address_by_script_hash(gw_context_t *ctx,
   _gw_fast_memcpy(eth_address, value + 12, ETH_ADDRESS_LEN);
   return 0;
 }
+
+// int load_account_id_by_eth_address(gw_context_t *ctx,
+//                               const uint8_t address[20],
+//                               uint32_t *account_id) {
+//   uint8_t script_hash[32] = {0};
+//   int ret = load_script_hash_by_eth_address(ctx, address, script_hash);
+//   if (ret != 0) {
+//     debug_print_int("load_script_hash_by_eth_address failed", ret);
+//     return ret;
+//   }
+//   return ctx->sys_get_account_id_by_script_hash(ctx, script_hash, account_id);
+// }
 
 void rlp_encode_sender_and_nonce(const evmc_address *sender, uint32_t nonce,
                                  uint8_t *data, uint32_t *data_len) {

--- a/c/sudt_contracts.h
+++ b/c/sudt_contracts.h
@@ -3,7 +3,6 @@
 #define SUDT_CONTRACTS_H_
 
 #include "polyjuice_utils.h"
-#include "polyjuice_globals.h"
 
 #define BALANCE_OF_ANY_SUDT_GAS 150
 #define TRANSFER_TO_ANY_SUDT_GAS 300

--- a/polyjuice-tests/src/helper.rs
+++ b/polyjuice-tests/src/helper.rs
@@ -48,8 +48,6 @@ pub const POLYJUICE_VALIDATOR_NAME: &str = "validator";
 pub const ETH_ADDRESS_REGISTRY_GENERATOR_NAME: &str = "eth-addr-reg-generator";
 pub const ETH_ADDRESS_REGISTRY_VALIDATOR_NAME: &str = "eth-addr-reg-validator";
 
-// del pub const ETH_ADDRESS_REGISTRY_PROGRAM_CODE_HASH: [u8; 32] = [6u8; 32];
-
 pub const ROLLUP_SCRIPT_HASH: [u8; 32] = [0xa9u8; 32];
 pub const ETH_ACCOUNT_LOCK_CODE_HASH: [u8; 32] = [0xaau8; 32];
 pub const SECP_LOCK_CODE_HASH: [u8; 32] = [0xbbu8; 32];
@@ -61,6 +59,12 @@ pub const GW_LOG_POLYJUICE_USER: u8 = 0x3;
 
 // pub const FATAL_POLYJUICE: i8 = -50;
 pub const FATAL_PRECOMPILED_CONTRACTS: i8 = -51;
+
+const GW_ETH_ADDRESS_TO_ACCOUNT_SCRIPT_HASH: u8 = 6;
+const GW_ACCOUNT_SCRIPT_HASH_TO_ETH_ADDRESS: u8 = 7;
+
+pub(crate) const SUDT_ERC20_PROXY_USER_DEFINED_DECIMALS_CODE: &str =
+    include_str!("../../solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.bin");
 
 fn load_program(program_name: &str) -> Bytes {
     let mut buf = Vec::new();
@@ -253,7 +257,11 @@ pub fn new_block_info(block_producer_id: u32, number: u64, timestamp: u64) -> Bl
         .build()
 }
 
-pub fn account_id_to_eth_address(state: &DummyState, id: u32, ethabi: bool) -> Vec<u8> {
+pub(crate) fn account_id_to_short_script_hash(
+    state: &DummyState,
+    id: u32,
+    ethabi: bool,
+) -> Vec<u8> {
     let offset = if ethabi { 12 } else { 0 };
     let mut data = vec![0u8; offset + 20];
     let account_script_hash = state.get_script_hash(id).unwrap();
@@ -290,7 +298,7 @@ pub fn new_account_script_with_nonce(
     from_id: u32,
     from_nonce: u32,
 ) -> Script {
-    let sender = account_id_to_eth_address(state, from_id, false);
+    let sender = account_id_to_short_script_hash(state, from_id, false);
     let mut stream = RlpStream::new_list(2);
     stream.append(&sender);
     stream.append(&from_nonce);
@@ -555,7 +563,7 @@ pub fn compute_create2_script(
 ) -> Script {
     assert_eq!(create2_salt.len(), 32);
 
-    let sender = account_id_to_eth_address(state, sender_account_id, false);
+    let sender = account_id_to_short_script_hash(state, sender_account_id, false);
     let init_code_hash = tiny_keccak::keccak256(init_code);
     let mut data = [0u8; 1 + 20 + 32 + 32];
     data[0] = 0xff;
@@ -652,4 +660,46 @@ pub fn check_cycles(l2_tx_label: &str, used_cycles: u64, warning_cycles: u64) {
         cycles_left,
         cycles_left * 100 / warning_cycles
     );
+}
+
+fn build_eth_address_to_script_hash_key(eth_address: &[u8; 20]) -> H256 {
+    let mut key: [u8; 32] = H256::zero().into();
+    let mut hasher = new_blake2b();
+    hasher.update(&gw_common::state::GW_NON_ACCOUNT_PLACEHOLDER);
+    hasher.update(&[GW_ETH_ADDRESS_TO_ACCOUNT_SCRIPT_HASH]);
+    hasher.update(eth_address);
+    hasher.finalize(&mut key);
+    key.into()
+}
+
+fn build_script_hash_to_eth_address_key(script_hash: &[u8; 32]) -> H256 {
+    let mut key: [u8; 32] = H256::zero().into();
+    let mut hasher = new_blake2b();
+    hasher.update(&gw_common::state::GW_NON_ACCOUNT_PLACEHOLDER);
+    hasher.update(&[GW_ACCOUNT_SCRIPT_HASH_TO_ETH_ADDRESS]);
+    hasher.update(script_hash);
+    hasher.finalize(&mut key);
+    key.into()
+}
+
+pub(crate) fn update_eth_address_registry(
+    state: &mut DummyState,
+    eth_address: &[u8; 20],
+    script_hash: &[u8; 32],
+) {
+    state
+        .update_raw(
+            build_eth_address_to_script_hash_key(eth_address),
+            script_hash.clone().into(),
+        )
+        .expect("add GW_ETH_ADDRESS_TO_SCRIPT_HASH mapping into state");
+
+    let mut eth_address_abi_format = [0u8; 32];
+    eth_address_abi_format[12..].copy_from_slice(eth_address);
+    state
+        .update_raw(
+            build_script_hash_to_eth_address_key(script_hash),
+            eth_address_abi_format.into(),
+        )
+        .expect("add GW_ACCOUNT_SCRIPT_HASH_TO_ETH_ADDRESS mapping into state");
 }

--- a/polyjuice-tests/src/helper.rs
+++ b/polyjuice-tests/src/helper.rs
@@ -45,8 +45,8 @@ pub const BIN_DIR: &str = "../build";
 pub const POLYJUICE_GENERATOR_NAME: &str = "generator";
 pub const POLYJUICE_VALIDATOR_NAME: &str = "validator";
 // ETH Address Registry
-pub const ETH_ADDRESS_REGISTRY_GENERATOR_NAME: &str = "eth-addr-reg-generator";
-pub const ETH_ADDRESS_REGISTRY_VALIDATOR_NAME: &str = "eth-addr-reg-validator";
+pub const ETH_ADDRESS_REGISTRY_GENERATOR_NAME: &str = "eth_addr_reg_generator";
+pub const ETH_ADDRESS_REGISTRY_VALIDATOR_NAME: &str = "eth_addr_reg_validator";
 
 pub const ROLLUP_SCRIPT_HASH: [u8; 32] = [0xa9u8; 32];
 pub const ETH_ACCOUNT_LOCK_CODE_HASH: [u8; 32] = [0xaau8; 32];

--- a/polyjuice-tests/src/test_cases/call_selfdestruct.rs
+++ b/polyjuice-tests/src/test_cases/call_selfdestruct.rs
@@ -2,8 +2,8 @@
 //!   See ./evm-contracts/SelfDestruct.sol
 
 use crate::helper::{
-    self, account_id_to_eth_address, build_eth_l2_script, contract_script_to_eth_address, deploy,
-    new_account_script_with_nonce, new_block_info, setup, PolyjuiceArgsBuilder,
+    self, account_id_to_short_script_hash, build_eth_l2_script, contract_script_to_eth_address,
+    deploy, new_account_script_with_nonce, new_block_info, setup, PolyjuiceArgsBuilder,
     CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
 };
 use gw_common::state::State;
@@ -48,7 +48,11 @@ fn test_selfdestruct() {
     let input = format!(
         "{}{}",
         SD_INIT_CODE,
-        hex::encode(account_id_to_eth_address(&state, beneficiary_id, true))
+        hex::encode(account_id_to_short_script_hash(
+            &state,
+            beneficiary_id,
+            true
+        ))
     );
     let run_result = deploy(
         &generator,

--- a/polyjuice-tests/src/test_cases/erc20.rs
+++ b/polyjuice-tests/src/test_cases/erc20.rs
@@ -2,7 +2,7 @@
 //!   See ./evm-contracts/ERC20.bin
 
 use crate::helper::{
-    self, account_id_to_eth_address, build_eth_l2_script, deploy, new_account_script,
+    self, account_id_to_short_script_hash, build_eth_l2_script, deploy, new_account_script,
     new_block_info, setup, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
 };
 use gw_common::state::State;
@@ -62,9 +62,9 @@ fn test_erc20() {
         .unwrap()
         .unwrap();
     let is_ethabi = true;
-    let eoa1_hex = hex::encode(account_id_to_eth_address(&state, from_id1, is_ethabi));
-    let eoa2_hex = hex::encode(account_id_to_eth_address(&state, from_id2, is_ethabi));
-    let eoa3_hex = hex::encode(account_id_to_eth_address(&state, from_id3, is_ethabi));
+    let eoa1_hex = hex::encode(account_id_to_short_script_hash(&state, from_id1, is_ethabi));
+    let eoa2_hex = hex::encode(account_id_to_short_script_hash(&state, from_id2, is_ethabi));
+    let eoa3_hex = hex::encode(account_id_to_short_script_hash(&state, from_id3, is_ethabi));
     for (idx, (from_id, args_str, return_data_str)) in [
         // balanceOf(eoa1)
         (

--- a/polyjuice-tests/src/test_cases/eth_addr_reg.rs
+++ b/polyjuice-tests/src/test_cases/eth_addr_reg.rs
@@ -5,7 +5,6 @@ use crate::helper::{
 use gw_generator::traits::StateExt;
 use gw_store::chain_view::ChainView;
 use gw_types::{
-    bytes::Bytes,
     core::ScriptHashType,
     packed::{RawL2Transaction, Script},
     prelude::*,
@@ -29,7 +28,7 @@ impl EthToGwArgsBuilder {
     pub fn build(self) -> Vec<u8> {
         let mut output: Vec<u8> = vec![0u8; 4];
         output[0..4].copy_from_slice(&self.method.to_le_bytes()[..]);
-        output.extend(self.eth_address.to_vec());
+        output.extend(self.eth_address);
         output
     }
 }
@@ -51,7 +50,38 @@ impl GwToEthArgsBuilder {
     pub fn build(self) -> Vec<u8> {
         let mut output: Vec<u8> = vec![0u8; 4];
         output[0..4].copy_from_slice(&self.method.to_le_bytes()[..]);
-        output.extend(self.gw_script_hash.to_vec());
+        output.extend(self.gw_script_hash);
+        output
+    }
+}
+
+#[derive(Default)]
+struct SetMappingArgsBuilder {
+    method: u32,
+    eth_address: [u8; 20],
+    gw_script_hash: [u8; 32],
+}
+impl SetMappingArgsBuilder {
+    /// Set the set mapping args builder's method.
+    fn method(mut self, method: u32) -> Self {
+        self.method = method;
+        self
+    }
+    /// Set the set mapping args builder's eth address.
+    fn eth_address(mut self, eth_address: [u8; 20]) -> Self {
+        self.eth_address = eth_address;
+        self
+    }
+    /// Set the set mapping args builder's gw script hash.
+    fn gw_script_hash(mut self, gw_script_hash: [u8; 32]) -> Self {
+        self.gw_script_hash = gw_script_hash;
+        self
+    }
+    fn build(self) -> Vec<u8> {
+        let mut output: Vec<u8> = vec![0u8; 4];
+        output[0..4].copy_from_slice(&self.method.to_le_bytes()[..]);
+        output.extend(self.eth_address);
+        output.extend(self.gw_script_hash);
         output
     }
 }
@@ -97,7 +127,7 @@ fn test_eth_to_gw() {
     let raw_tx = RawL2Transaction::new_builder()
         .from_id(a_id.pack())
         .to_id(eth_addr_reg_account_id.pack())
-        .args(Bytes::from(args).pack())
+        .args(args.pack())
         .build();
     let block_info = new_block_info(a_id, 1, 0);
     let tip_block_hash = store.get_tip_block_hash().unwrap();
@@ -157,12 +187,120 @@ fn test_gw_to_eth() {
     let raw_l2tx = RawL2Transaction::new_builder()
         .from_id(a_id.pack())
         .to_id(eth_addr_reg_account_id.pack())
-        .args(Bytes::from(args).pack())
+        .args(args.pack())
         .build();
     let db = store.begin_transaction();
     let tip_block_hash = store.get_tip_block_hash().unwrap();
     let block_info = new_block_info(a_id, 1, 0);
 
+    let run_result = generator
+        .execute_transaction(
+            &ChainView::new(&db, tip_block_hash),
+            &state,
+            &block_info,
+            &raw_l2tx,
+            L2TX_MAX_CYCLES,
+        )
+        .expect("execute Godwoken contract");
+    assert_eq!(run_result.return_data, eth_address);
+}
+
+#[test]
+fn test_set_mappting_by_contract() {
+    let (store, mut state, generator, _creator_account_id) = setup();
+
+    // init accounts
+    let eth_addr_reg_account_id = state
+        .create_account_from_script(
+            Script::new_builder()
+                .code_hash(ETH_ADDRESS_REGISTRY_PROGRAM_CODE_HASH.clone().pack())
+                .args([0u8; 32].to_vec().pack())
+                .hash_type(ScriptHashType::Type.into())
+                .build(),
+        )
+        .expect("create eth_addr_reg_account");
+
+    let from_id = state
+        .create_account_from_script(
+            Script::new_builder()
+                .code_hash([0u8; 32].pack())
+                .args([0u8; 20].to_vec().pack())
+                .hash_type(ScriptHashType::Type.into())
+                .build(),
+        )
+        .expect("create account a");
+
+    let gw_account_script_hash = [8u8; 32];
+    let eth_address = <[u8; 20]>::from_hex("D1667CBf1cc60da94c1cf6C9cfb261e71b6047f7")
+        .expect("eth_address hex_string to u8_vec");
+
+    // update_eth_address_registry
+    let args = SetMappingArgsBuilder::default()
+        .method(2u32)
+        .eth_address(eth_address)
+        .gw_script_hash(gw_account_script_hash)
+        .build();
+    let raw_l2tx = RawL2Transaction::new_builder()
+        .from_id(from_id.pack())
+        .to_id(eth_addr_reg_account_id.pack())
+        .args(args.pack())
+        .build();
+    let db = store.begin_transaction();
+    let tip_block_hash = store.get_tip_block_hash().unwrap();
+    let block_info = new_block_info(from_id, 1, 0);
+    let run_result = generator
+        .execute_transaction(
+            &ChainView::new(&db, tip_block_hash),
+            &state,
+            &block_info,
+            &raw_l2tx,
+            L2TX_MAX_CYCLES,
+        )
+        .expect("execute Godwoken contract");
+    state.apply_run_result(&run_result).expect("update state");
+    assert_eq!(run_result.exit_code, 0);
+
+    // check result: eth_address -> gw_script_hash
+    let args = EthToGwArgsBuilder::default()
+        .method(0u32)
+        .eth_address(eth_address)
+        .build();
+    let raw_l2tx = RawL2Transaction::new_builder()
+        .from_id(from_id.pack())
+        .to_id(eth_addr_reg_account_id.pack())
+        .args(args.pack())
+        .build();
+    let block_info = new_block_info(from_id, 2, 0);
+    let tip_block_hash = store.get_tip_block_hash().unwrap();
+    let db = store.begin_transaction();
+    let run_result = generator
+        .execute_transaction(
+            &ChainView::new(&db, tip_block_hash),
+            &state,
+            &block_info,
+            &raw_l2tx,
+            L2TX_MAX_CYCLES,
+        )
+        .expect("execute Godwoken contract");
+    state.apply_run_result(&run_result).expect("update state");
+    assert_eq!(
+        run_result.return_data,
+        gw_account_script_hash
+    );
+
+    // check result: gw_script_hash -> eth_address
+    let args = GwToEthArgsBuilder::default()
+        .method(1u32)
+        .gw_script_hash(gw_account_script_hash)
+        .build();
+    let raw_l2tx = RawL2Transaction::new_builder()
+        .from_id(from_id.pack())
+        .to_id(eth_addr_reg_account_id.pack())
+        .args(args.pack())
+        .build();
+    let db = store.begin_transaction();
+    let tip_block_hash = store.get_tip_block_hash().unwrap();
+    let block_info = new_block_info(from_id, 3, 0);
     let run_result = generator
         .execute_transaction(
             &ChainView::new(&db, tip_block_hash),

--- a/polyjuice-tests/src/test_cases/eth_to_godwoken_addr.rs
+++ b/polyjuice-tests/src/test_cases/eth_to_godwoken_addr.rs
@@ -2,7 +2,8 @@
 
 use crate::helper::{
     self, build_eth_l2_script, deploy, new_account_script, new_block_info, setup,
-    PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, POLYJUICE_PROGRAM_CODE_HASH, ROLLUP_SCRIPT_HASH,
+    PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES, POLYJUICE_PROGRAM_CODE_HASH,
+    ROLLUP_SCRIPT_HASH,
 };
 use gw_common::state::State;
 use gw_generator::traits::StateExt;

--- a/polyjuice-tests/src/test_cases/get_block_info.rs
+++ b/polyjuice-tests/src/test_cases/get_block_info.rs
@@ -2,8 +2,8 @@
 //!   See ./evm-contracts/BlockInfo.sol
 
 use crate::helper::{
-    account_id_to_eth_address, build_eth_l2_script, new_account_script, new_block_info, setup,
-    PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
+    account_id_to_short_script_hash, build_eth_l2_script, new_account_script, new_block_info,
+    setup, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
 };
 use gw_common::state::State;
 use gw_db::schema::COLUMN_INDEX;
@@ -47,7 +47,11 @@ fn test_get_block_info() {
     let aggregator_script = build_eth_l2_script([2u8; 20]);
     let aggregator_id = state.create_account_from_script(aggregator_script).unwrap();
     assert_eq!(aggregator_id, 5);
-    let coinbase_hex = hex::encode(&account_id_to_eth_address(&state, aggregator_id, true));
+    let coinbase_hex = hex::encode(&account_id_to_short_script_hash(
+        &state,
+        aggregator_id,
+        true,
+    ));
     println!("coinbase_hex: {}", coinbase_hex);
 
     // Deploy BlockInfo

--- a/polyjuice-tests/src/test_cases/invalid_sudt_erc20_proxy.rs
+++ b/polyjuice-tests/src/test_cases/invalid_sudt_erc20_proxy.rs
@@ -2,7 +2,7 @@
 //!   See ./evm-contracts/ERC20.bin
 
 use crate::helper::{
-    self, account_id_to_eth_address, build_eth_l2_script, build_l2_sudt_script, deploy,
+    self, account_id_to_short_script_hash, build_eth_l2_script, build_l2_sudt_script, deploy,
     new_account_script, new_block_info, setup, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID,
     L2TX_MAX_CYCLES,
 };
@@ -81,9 +81,9 @@ fn test_invalid_sudt_erc20_proxy() {
         .unwrap()
         .unwrap();
     let is_ethabi = true;
-    let eoa1_hex = hex::encode(account_id_to_eth_address(&state, from_id1, is_ethabi));
-    let eoa2_hex = hex::encode(account_id_to_eth_address(&state, from_id2, is_ethabi));
-    let eoa3_hex = hex::encode(account_id_to_eth_address(&state, from_id3, is_ethabi));
+    let eoa1_hex = hex::encode(account_id_to_short_script_hash(&state, from_id1, is_ethabi));
+    let eoa2_hex = hex::encode(account_id_to_short_script_hash(&state, from_id2, is_ethabi));
+    let eoa3_hex = hex::encode(account_id_to_short_script_hash(&state, from_id3, is_ethabi));
     println!("eoa1_hex: {}", eoa1_hex);
     println!("eoa2_hex: {}", eoa2_hex);
     println!("eoa3_hex: {}", eoa3_hex);

--- a/polyjuice-tests/src/test_cases/metamask_transactions.rs
+++ b/polyjuice-tests/src/test_cases/metamask_transactions.rs
@@ -1,0 +1,190 @@
+//! Test transfer from EoA to EoA using Metamask
+
+use crate::helper::{
+    build_eth_l2_script, deploy, new_account_script, new_block_info, setup,
+    update_eth_address_registry, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
+    SUDT_ERC20_PROXY_USER_DEFINED_DECIMALS_CODE,
+};
+use gw_common::state::State;
+use gw_generator::traits::StateExt;
+use gw_store::chain_view::ChainView;
+use gw_types::{bytes::Bytes, packed::RawL2Transaction, prelude::*};
+
+#[test]
+fn test_transfer_by_metamask() {
+    let (store, mut state, generator, creator_account_id) = setup();
+
+    let block_producer_script = build_eth_l2_script([0x99u8; 20]);
+    let block_producer_script_hash = block_producer_script.hash();
+    let block_producer_id = state
+        .create_account_from_script(block_producer_script)
+        .unwrap();
+    state
+        .mint_sudt(
+            CKB_SUDT_ACCOUNT_ID,
+            &block_producer_script_hash[..20],
+            2000000,
+        )
+        .unwrap();
+
+    let eth_address1 = [1u8; 20];
+    let from_script1 = build_eth_l2_script(eth_address1.clone());
+    let from_script_hash1 = from_script1.hash();
+    let from_id1 = state.create_account_from_script(from_script1).unwrap();
+    update_eth_address_registry(&mut state, &eth_address1, &from_script_hash1);
+
+    let eth_address2 = [2u8; 20];
+    let from_script2 = build_eth_l2_script(eth_address2.clone());
+    let from_script_hash2 = from_script2.hash();
+    let _from_id2 = state.create_account_from_script(from_script2).unwrap();
+    update_eth_address_registry(&mut state, &eth_address2, &from_script_hash2);
+
+    let eth_address3 = [3u8; 20];
+    let from_script3 = build_eth_l2_script(eth_address3.clone());
+    let from_script_hash3 = from_script3.hash();
+    let _from_short_address3 = &from_script_hash3[0..20];
+    let _from_id3 = state.create_account_from_script(from_script3).unwrap();
+    update_eth_address_registry(&mut state, &eth_address3, &from_script_hash3);
+
+    state
+        .mint_sudt(CKB_SUDT_ACCOUNT_ID, &from_script_hash1[..20], 2000000)
+        .unwrap();
+    // state
+    //     .mint_sudt(CKB_SUDT_ACCOUNT_ID, from_short_address3, 80000)
+    //     .unwrap();
+
+    // deploy SudtERC20Proxy contract
+    let block_number = 1;
+    let args = format!("00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000024cb016ea00000000000000000000000000000000000000000000000000000000000000{:02x}00000000000000000000000000000000000000000000000000000000000000{:02x}000000000000000000000000000000000000000000000000000000000000000e65726332305f646563696d616c7300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034445430000000000000000000000000000000000000000000000000000000000", CKB_SUDT_ACCOUNT_ID, 8);
+    let init_code = format!("{}{}", SUDT_ERC20_PROXY_USER_DEFINED_DECIMALS_CODE, args);
+    let _run_result = deploy(
+        &generator,
+        &store,
+        &mut state,
+        creator_account_id,
+        block_producer_id,
+        init_code.as_str(),
+        122000,
+        0,
+        block_producer_id,
+        block_number,
+    );
+    let ckb_proxy_contract_script =
+        new_account_script(&state, creator_account_id, block_producer_id, false);
+    let script_hash = ckb_proxy_contract_script.hash();
+    let ckb_proxy_contract_account_id = state
+        .get_account_id_by_script_hash(&script_hash.into())
+        .unwrap()
+        .unwrap();
+    let mut eth_address_of_ckb_proxy_contract = [0u8; 20];
+    eth_address_of_ckb_proxy_contract[..20].copy_from_slice(&script_hash[0..20]);
+    update_eth_address_registry(&mut state, &eth_address_of_ckb_proxy_contract, &script_hash);
+
+    // assume that Ethereum JSON RPC request sent by Metamask is:
+    // ```JSON
+    // {
+    //   method: 'eth_sendTransaction',
+    //   params: [
+    //     {
+    //       from: eth_address1,
+    //       to: eth_address3,
+    //       value: '0x29a2241af62c0000',
+    //       gasPrice: '0x09184e72a000',
+    //       gas: '0x2710',
+    //     },
+    //   ],
+    // }
+    // ```
+    //
+    // if tx.data is null && to_address is EoA or notExistEoA,
+    // then handle it as a simple pETH transfer, using ERC20_Proxy(sUDT_ID = 1)
+    //
+    // The RawL2Transaction from Web3 RPC to Godwoken RPC:
+    // {
+    //     from_id: from_id1,
+    //     to_id: ckb_proxy_contract_account_id,
+    //     nonce: Uint32,
+    //     args: Bytes,
+    // }
+    // the args above:
+    //     header     : [u8; 8]   (header[0..7] = "ETHPOLY",
+    //                             header[7]    = call_kind { 0: CALL, 3: CREATE })
+    //     gas_limit  : u64      (little endian)
+    //     gas_price  : u128     (little endian)
+    //     value      : u128     (little endian)
+    //     input_size : u32      (little endian)
+    //     input_data : [u8; input_size]   (input data)
+    // the input_data contains native eth_addresses:
+    println!("eth_address1: {}", hex::encode(eth_address1));
+    println!("eth_address2: {}", hex::encode(eth_address2));
+    println!("eth_address3: {}", hex::encode(eth_address3));
+    for (idx, (from_id, args_str, return_data_str)) in [
+        // balanceOf(eoa1)
+        (
+            from_id1,
+            format!("70a08231000000000000000000000000{}", hex::encode(eth_address1)),
+            "00000000000000000000000000000000000000000000000000000000001E8480",
+        ),
+        // balanceOf(eoa2)
+        (
+            from_id1,
+            format!("70a08231000000000000000000000000{}", hex::encode(eth_address2)),
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        // transfer("eoa2", 0x480)
+        (
+            from_id1,
+            format!(
+                "a9059cbb000000000000000000000000{}0000000000000000000000000000000000000000000000000000000000000480",
+                hex::encode(eth_address2)
+            ),
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        ),
+        // balanceOf(eoa2)
+        (
+            from_id1,
+            format!("70a08231000000000000000000000000{}", hex::encode(eth_address2)),
+            "0000000000000000000000000000000000000000000000000000000000000480",
+        ),
+    ]
+    .iter()
+    .enumerate()
+    {
+        println!("test index: {}", idx);
+        let block_number = 2 + idx as u64;
+        let block_info = new_block_info(block_producer_id, block_number, block_number);
+        let input = hex::decode(args_str).unwrap();
+        let args = PolyjuiceArgsBuilder::default()
+            .using_native_eth_address(true) // use new L2TX format
+            .gas_limit(80000)
+            .gas_price(1)
+            .value(0)
+            .input(&input)
+            .build();
+        let raw_tx = RawL2Transaction::new_builder()
+            .from_id(from_id.pack())
+            .to_id(ckb_proxy_contract_account_id.pack())
+            .args(Bytes::from(args).pack())
+            .build();
+        let db = store.begin_transaction();
+        let tip_block_hash = store.get_tip_block_hash().unwrap();
+        let run_result = generator
+            .execute_transaction(
+                &ChainView::new(&db, tip_block_hash),
+                &state,
+                &block_info,
+                &raw_tx,
+                L2TX_MAX_CYCLES,
+            )
+            .expect("transfer from EoA to EoA, using native_eth_address");
+        state.apply_run_result(&run_result).expect("update state");
+        assert_eq!(
+            run_result.return_data,
+            hex::decode(return_data_str).unwrap()
+        );
+    }
+    // println!(
+    //     "result {}",
+    //     serde_json::to_string_pretty(&RunResult::from(run_result)).unwrap()
+    // );
+}

--- a/polyjuice-tests/src/test_cases/mod.rs
+++ b/polyjuice-tests/src/test_cases/mod.rs
@@ -28,4 +28,4 @@ pub(crate) mod invalid_sudt_erc20_proxy;
 pub(crate) mod sudt_erc20_proxy;
 
 mod eth_addr_reg;
-// mod eoa_transfer_to_eoa;
+mod metamask_transactions;

--- a/polyjuice-tests/src/test_cases/parse_log_event.rs
+++ b/polyjuice-tests/src/test_cases/parse_log_event.rs
@@ -2,8 +2,9 @@
 //!   See ./evm-contracts/LogEvents.sol
 
 use crate::helper::{
-    account_id_to_eth_address, build_eth_l2_script, deploy, new_account_script, new_block_info,
-    parse_log, setup, Log, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
+    account_id_to_short_script_hash, build_eth_l2_script, deploy, new_account_script,
+    new_block_info, parse_log, setup, Log, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID,
+    L2TX_MAX_CYCLES,
 };
 use gw_common::state::State;
 use gw_generator::traits::StateExt;
@@ -95,13 +96,13 @@ fn test_parse_log_event() {
         {
             assert_eq!(
                 &address[..],
-                &account_id_to_eth_address(&state, new_account_id, false)[..]
+                &account_id_to_short_script_hash(&state, new_account_id, false)[..]
             );
             assert_eq!(data[31], deploy_value as u8);
             assert_eq!(data[63], 1); // true
             assert_eq!(
                 topics[1].as_slice(),
-                account_id_to_eth_address(&state, from_id, true)
+                account_id_to_short_script_hash(&state, from_id, true)
             );
         } else {
             panic!("unexpected polyjuice log");
@@ -196,13 +197,13 @@ fn test_parse_log_event() {
             {
                 assert_eq!(
                     &address[..],
-                    &account_id_to_eth_address(&state, new_account_id, false)[..]
+                    &account_id_to_short_script_hash(&state, new_account_id, false)[..]
                 );
                 assert_eq!(data[31], call_value as u8);
                 assert_eq!(data[63], 0); // false
                 assert_eq!(
                     topics[1].as_slice(),
-                    account_id_to_eth_address(&state, from_id, true)
+                    account_id_to_short_script_hash(&state, from_id, true)
                 );
             } else {
                 panic!("unexpected polyjuice log");

--- a/polyjuice-tests/src/test_cases/selfdestruct.rs
+++ b/polyjuice-tests/src/test_cases/selfdestruct.rs
@@ -2,7 +2,7 @@
 //!   See ./evm-contracts/SelfDestruct.sol
 
 use crate::helper::{
-    self, account_id_to_eth_address, build_eth_l2_script, new_account_script, new_block_info,
+    self, account_id_to_short_script_hash, build_eth_l2_script, new_account_script, new_block_info,
     setup, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
 };
 use gw_common::state::State;
@@ -45,7 +45,11 @@ fn test_selfdestruct() {
         // Deploy SelfDestruct
         let block_info = new_block_info(0, 1, 0);
         let mut input = hex::decode(INIT_CODE).unwrap();
-        input.extend(account_id_to_eth_address(&state, beneficiary_id, true));
+        input.extend(account_id_to_short_script_hash(
+            &state,
+            beneficiary_id,
+            true,
+        ));
         let args = PolyjuiceArgsBuilder::default()
             .do_create(true)
             .gas_limit(22000)

--- a/polyjuice-tests/src/test_cases/simple_transfer.rs
+++ b/polyjuice-tests/src/test_cases/simple_transfer.rs
@@ -2,8 +2,8 @@
 //!   See ./evm-contracts/SimpleTransfer.sol
 
 use crate::helper::{
-    self, account_id_to_eth_address, build_eth_l2_script, contract_script_to_eth_address, deploy,
-    new_account_script, new_block_info, setup, simple_storage_get, PolyjuiceArgsBuilder,
+    self, account_id_to_short_script_hash, build_eth_l2_script, contract_script_to_eth_address,
+    deploy, new_account_script, new_block_info, setup, simple_storage_get, PolyjuiceArgsBuilder,
     CKB_SUDT_ACCOUNT_ID, L2TX_MAX_CYCLES,
 };
 use gw_common::state::State;
@@ -136,7 +136,7 @@ fn test_simple_transfer() {
         let block_info = new_block_info(block_producer_id, block_number, block_number);
         let input = hex::decode(format!(
             "a03fa7e3{}",
-            hex::encode(account_id_to_eth_address(&state, target_id, true)),
+            hex::encode(account_id_to_short_script_hash(&state, target_id, true)),
         ))
         .unwrap();
         let args = PolyjuiceArgsBuilder::default()

--- a/polyjuice-tests/src/test_cases/sudt_erc20_proxy.rs
+++ b/polyjuice-tests/src/test_cases/sudt_erc20_proxy.rs
@@ -2,9 +2,9 @@
 //!   See ./evm-contracts/ERC20.bin
 
 use crate::helper::{
-    account_id_to_eth_address, build_eth_l2_script, build_l2_sudt_script, deploy,
+    account_id_to_short_script_hash, build_eth_l2_script, build_l2_sudt_script, deploy,
     new_account_script, new_block_info, setup, PolyjuiceArgsBuilder, CKB_SUDT_ACCOUNT_ID,
-    FATAL_PRECOMPILED_CONTRACTS, L2TX_MAX_CYCLES,
+    FATAL_PRECOMPILED_CONTRACTS, L2TX_MAX_CYCLES, SUDT_ERC20_PROXY_USER_DEFINED_DECIMALS_CODE,
 };
 use gw_common::state::State;
 use gw_generator::{dummy_state::DummyState, error::TransactionError, traits::StateExt, Generator};
@@ -12,8 +12,6 @@ use gw_store::{chain_view::ChainView, Store};
 use gw_types::{bytes::Bytes, packed::RawL2Transaction, prelude::*};
 
 const SUDT_ERC20_PROXY_CODE: &str = include_str!("../../../solidity/erc20/SudtERC20Proxy.bin");
-const SUDT_ERC20_PROXY_USER_DEFINED_DECIMALS_CODE: &str =
-    include_str!("../../../solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.bin");
 
 fn test_sudt_erc20_proxy_inner(
     generator: &Generator,
@@ -105,9 +103,9 @@ fn test_sudt_erc20_proxy_inner(
         .unwrap()
         .unwrap();
     let is_ethabi = true;
-    let eoa1_hex = hex::encode(account_id_to_eth_address(state, from_id1, is_ethabi));
-    let eoa2_hex = hex::encode(account_id_to_eth_address(state, from_id2, is_ethabi));
-    let eoa3_hex = hex::encode(account_id_to_eth_address(state, from_id3, is_ethabi));
+    let eoa1_hex = hex::encode(account_id_to_short_script_hash(state, from_id1, is_ethabi));
+    let eoa2_hex = hex::encode(account_id_to_short_script_hash(state, from_id2, is_ethabi));
+    let eoa3_hex = hex::encode(account_id_to_short_script_hash(state, from_id3, is_ethabi));
     println!("eoa1_hex: {}", eoa1_hex);
     println!("eoa2_hex: {}", eoa2_hex);
     println!("eoa3_hex: {}", eoa3_hex);


### PR DESCRIPTION
In the latest version of Polyjuice, the EOA addresses are native `eth_address`, which is the rightmost 160 bits of a Keccak hash of an ECDSA public key.

- Support new L2TX format with native eth_address
   * new L2TX format: `polyjuice_args.header[0..7] = "ETHPOLY"`
- test: mock transfer from EoA to EoA using Metamask
- Update docs
   * update the header format of Polyjuice.args 
