### PR TITLE
refactor: add eth_addr_reg_id into creator_script.args

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ hash_type: type
 args:
     rollup_type_hash : [u8; 32]
     sudt_id          : u32          (little endian, the token id)
+    eth_addr_reg_id  : u32          (little endian, the ETH_Address_Registry Contract id)
 ```
 
-Polyjuice creator account is a godwoken account for creating Polyjuice contract account. This account can only been created by [meta contract][meta-contract], and the account id is used as the chain id in Polyjuice. The `sudt_id` field in script args is the sudt token current Polyjuice instance bind to.
+Polyjuice creator account is a godwoken account for creating Polyjuice contract account. This account can only be created by [meta contract][meta-contract], and the account id is used as the chain id in Polyjuice. The `sudt_id` field in script args is the sUDT token current Polyjuice instance bind to as [`pETH`](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_polyjuice_transaction.md#peth). The `eth_addr_reg_id` field in script args is the id of `ETH Address Registry` layer2 contract which provides two-ways mappings between `eth_address` and `gw_script_hash`.
 
 ### Contract account script
 

--- a/c/polyjuice_globals.h
+++ b/c/polyjuice_globals.h
@@ -12,6 +12,7 @@
 
 /** Polyjuice contract account (normal/create2) script args size */
 #define CONTRACT_ACCOUNT_SCRIPT_ARGS_LEN 56       /* 32 + 4 + 20 */
+#define CREATOR_SCRIPT_ARGS_LEN          40       /* 32 + 4 + 4  */
 
 static uint8_t g_rollup_script_hash[32] = {0};
 static uint32_t g_sudt_id = UINT32_MAX;
@@ -25,9 +26,14 @@ static uint32_t g_created_id = UINT32_MAX;
 
 /**
  * creator_account, known as root account
- * see also: https://github.com/nervosnetwork/godwoken/blob/5735d8f/docs/life_of_a_polyjuice_transaction.md#root-account--deployment
+ * @see https://github.com/nervosnetwork/godwoken/blob/5735d8f/docs/life_of_a_polyjuice_transaction.md#root-account--deployment
  */
 static uint32_t g_creator_account_id = UINT32_MAX;
+/**
+ * ETH_Address_Registry Contract Account
+ * @see c/eth_addr_reg.c
+ */
+static uint32_t g_eth_addr_reg_id = UINT32_MAX;
 
 static evmc_address g_tx_origin = {0};
 

--- a/c/polyjuice_utils.h
+++ b/c/polyjuice_utils.h
@@ -100,29 +100,34 @@ int build_script(const uint8_t code_hash[32], const uint8_t hash_type,
   return 0;
 }
 
+/**
+ * @brief Generate a SMT key
+ * @param script_hash 
+ * @param raw_key = blake2b(g_eth_addr_reg_id | type | script_hash)
+ */
 void gw_build_script_hash_to_eth_address_key(
     const uint8_t script_hash[GW_KEY_BYTES], uint8_t raw_key[GW_KEY_BYTES]) {
   blake2b_state blake2b_ctx;
   blake2b_init(&blake2b_ctx, GW_KEY_BYTES);
-  uint32_t placeholder = 0;
-  blake2b_update(&blake2b_ctx, (uint8_t *)&placeholder, sizeof(uint32_t));
+  blake2b_update(&blake2b_ctx, (uint8_t *)&g_eth_addr_reg_id, sizeof(uint32_t));
   uint8_t type = GW_ACCOUNT_SCRIPT_HASH_TO_ETH_ADDR;
   blake2b_update(&blake2b_ctx, (uint8_t *)&type, 1);
   blake2b_update(&blake2b_ctx, script_hash, GW_KEY_BYTES);
   blake2b_final(&blake2b_ctx, raw_key, GW_KEY_BYTES);
 }
 
+/**
+ * @brief Generate a SMT key
+ * @param eth_address 
+ * @param raw_key = blake2b(g_eth_addr_reg_id | type | eth_address)
+ */
 void gw_build_eth_addr_to_script_hash_key(
     const uint8_t eth_address[ETH_ADDRESS_LEN], uint8_t raw_key[GW_KEY_BYTES]) {
   blake2b_state blake2b_ctx;
   blake2b_init(&blake2b_ctx, GW_KEY_BYTES);
-  /* placeholder: 0 */
-  uint32_t placeholder = 0;
-  blake2b_update(&blake2b_ctx, (uint8_t *)&placeholder, sizeof(uint32_t));
-  /* type */
+  blake2b_update(&blake2b_ctx, (uint8_t *)&g_eth_addr_reg_id, sizeof(uint32_t));
   uint8_t type = ETH_ADDR_TO_GW_ACCOUNT_SCRIPT_HASH;
   blake2b_update(&blake2b_ctx, (uint8_t *)&type, 1);
-  /* eth_address */
   blake2b_update(&blake2b_ctx, eth_address, ETH_ADDRESS_LEN);
   blake2b_final(&blake2b_ctx, raw_key, GW_KEY_BYTES);
 }


### PR DESCRIPTION
- ### Update Creator account script
```
code_hash: Polyjuice_validator_type_script_hash
hash_type: type
args:
    rollup_type_hash : [u8; 32]
    sudt_id          : u32          (little endian, the token id)
    eth_addr_reg_id  : u32          (little endian, the ETH_Address_Registry Contract id)
```

Polyjuice creator account is a godwoken account for creating Polyjuice contract account. This account can only be created by [meta contract](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_godwoken_transaction.md#metacontract), and the account id is used as the chain id in Polyjuice. The `sudt_id` field in script args is the sUDT token current Polyjuice instance bind to as [`pETH`](https://github.com/nervosnetwork/godwoken/blob/master/docs/life_of_a_polyjuice_transaction.md#peth). The `eth_addr_reg_id` field in script args is the id of `ETH Address Registry` layer2 contract which provides two-ways mappings between `eth_address` and `gw_script_hash`.

- ### use eth_addr_registry_id in `gw_build_script_hash_to_eth_address_key` and `gw_build_eth_addr_to_script_hash_key`