### PR TITLE
docs: How to debug Polyjuice generator on x86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ build/
 target/
 integration-test/
 
-/.vscode/launch.json
 /.vscode/settings.json
 /.vscode/*.log
 .vscode/c_cpp_properties.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,74 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "clang - debug polyjuice_generator_fuzzer_log",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/polyjuice-tests/fuzz/build/polyjuice_generator_fuzzer_log",
+            "args": [
+                "timeout-7635939a9881e94453a1a5924858567ad3b46987",
+                // "corpus/regression/oom-09125a5f1a09707e5d7cd065158f9a545a07f598",
+                // "crash-9898a2cd67e8dadb6d56c32174446bed5fe43e50",
+                // "timeout-9c268a5f718afb1b790ad324ada4fda8a37562ec",
+                // "corpus",
+
+                // "-merge=1 NEW_CORPUS_DIR corpus",
+                // "-max_len=25000", // Max data buffer size: 24KB < 25000 bytes
+                // "-timeout=120"
+                "-max_total_time=3"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/polyjuice-tests/fuzz",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "(C/C++) Launch active file",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${fileDirname}/${fileBasenameNoExtension}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ], "preLaunchTask": "==build active file=="
+        },{
+            "name": "clang - Build and debug test_contracts",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/polyjuice-tests/fuzz/build/test_contracts",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/polyjuice-tests/fuzz",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/polyjuice-tests/fuzz/README.md
+++ b/polyjuice-tests/fuzz/README.md
@@ -2,7 +2,7 @@
 
 [![FuzzTest](https://github.com/Flouse/godwoken-polyjuice/actions/workflows/fuzz.yml/badge.svg?branch=fuzz-v2)](https://github.com/Flouse/godwoken-polyjuice/actions/workflows/fuzz.yml)
 
-These three file were created to simulate `gw_syscalls`:
+These two file were created to simulate `gw_syscalls`:
 - polyjuice-tests/fuzz/ckb_syscalls.h
 - polyjuice-tests/fuzz/mock_godwoken.hpp
 
@@ -37,6 +37,15 @@ make build/test_contracts
 make build/test_rlp
 ./build/test_rlp
 ```
+
+## How to debug Polyjuice generator on x86?
+1. Compile Polyjuice generator on x86
+    ```bash
+    cd fuzz
+    make build/polyjuice_generator_fuzzer
+    ```
+2. Construct `pre_defined_test_case` in [polyjuice_generator_fuzzer.cc](./polyjuice_generator_fuzzer.cc)
+3. Run `build/polyjuice_generator_fuzzer_log` with GDB debugger, see: [launch.json](../../.vscode/launch.json) 
 
 ## Coverage Report[WIP]
 TBD


### PR DESCRIPTION
## How to debug Polyjuice generator on x86?
1. Compile Polyjuice generator on x86
    ```bash
    cd polyjuice-tests/fuzz
    make build/polyjuice_generator_fuzzer
    ```
2. Construct `pre_defined_test_case` in [polyjuice_generator_fuzzer.cc](./polyjuice_generator_fuzzer.cc)
3. Run `build/polyjuice_generator_fuzzer_log` with GDB debugger
see: launch.json