### PR TITLE
test: set rollup_type_hash into the args of eth_addr_reg_script

### DIFF
--- a/polyjuice-tests/src/helper.rs
+++ b/polyjuice-tests/src/helper.rs
@@ -425,6 +425,7 @@ pub fn setup() -> (Store, DummyState, Generator) {
     let eth_addr_reg_script = Script::new_builder()
         .code_hash(ETH_ADDRESS_REGISTRY_PROGRAM_CODE_HASH.pack())
         .hash_type(ScriptHashType::Type.into())
+        .args(ROLLUP_SCRIPT_HASH.to_vec().pack())
         .build();
     let eth_addr_reg_account_id = state
         .create_account_from_script(eth_addr_reg_script)


### PR DESCRIPTION
see [fix(tool): set rollup_type_hash into the args of eth_addr_reg_script](https://github.com/nervosnetwork/godwoken/pull/587/commits/4669cb02ca1732aab5bcc77f7a1ef92896ef74ab) in [Godwoken](https://github.com/nervosnetwork/godwoken/pull/587)