### PR TITLE
docs: update EVM-compatible.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 # Godwoken Polyjuice
-An Ethereum compatible backend for [Godwoken](https://github.com/nervosnetwork/godwoken) rollup framework. It include generator and validator implementations.
+An Ethereum compatible backend for [Godwoken](https://github.com/nervosnetwork/godwoken) rollup framework. It includes [generator](./c/generator.c) and [validator](./c/validator.c) implementations.
 
-Polyjuice provides an [Ethereum](https://ethereum.org/en/) compatible layer on [Nervos CKB](https://github.com/nervosnetwork/ckb). It leverages account model as well as scalability provided by [Godwoken](./life_of_a_godwoken_transaction.md), then integrates [evmone](https://github.com/ethereum/evmone) as an EVM engine for running Ethereum smart contracts.
+Polyjuice provides an [Ethereum](https://ethereum.org/en/) compatible layer on [Nervos CKB](https://github.com/nervosnetwork/ckb). It leverages account model as well as scalability provided by [Godwoken](https://github.com/nervosnetwork/godwoken/blob/9de340c/docs/life_of_a_godwoken_transaction.md), then integrates [evmone](https://github.com/ethereum/evmone) as an EVM engine for running Ethereum smart contracts.
 
 Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. See [EVM-compatible.md](docs/EVM-compatible.md) and [Addition-Features.md](docs/Addition-Features.md) for more details.
 
@@ -78,7 +78,7 @@ info_data: rlp_encode(sender_address, sender_nonce)
 The Polyjuice contract account created in Polyjuice by `CREATE2` Opcode.
 ```
 info_data:
-    special_byte    : u8         (value is '0xff', refer to ethereum)
+    special_byte    : u8         (value is '0xff', refer to Ethereum)
     sender_address  : [u8; 20]   (the msg.sender: blake128(sender_script) + account id)
     create2_salt    : [u8; 32]   (create2 salt)
     init_code_hash  : [u8; 32]   (keccak256(init_code))
@@ -88,7 +88,7 @@ info_data:
 In the latest version of Polyjuice, the [EOA](https://ethereum.org/en/glossary/#eoa) address is native `eth_address`, which is the rightmost 160 bits of a Keccak hash of an ECDSA public key. While the address for an Polyjuice contract is deterministically computed from the address of its creator (sender) and how many transactions the creator has sent (nonce). The sender and nonce are RLP encoded and then hashed with Keccak-256.
 
 > In the previous version of Polyjuice, all the addresses are `short_godwoken_account_script_hash`, which is:
-``` rust
+```rust
 short_godwoken_account_script_hash = blake2b(script.as_slice())[0..20]
 ```
 

--- a/docs/Addition-Features.md
+++ b/docs/Addition-Features.md
@@ -73,7 +73,7 @@ See: [Example](../solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol)
    input[12..32] => ETH address
 
  output:
-   output[12..32] => godwoken short address
+   output[12..32] => short_gw_script_hash
 ```
 
 See: [Example](../polyjuice-tests/src/test_cases/evm-contracts/EthToGodwokenAddr.sol)

--- a/docs/EVM-compatible.md
+++ b/docs/EVM-compatible.md
@@ -2,23 +2,28 @@
 
 Polyjuice aims at 100% EVM compatibility as a goal, meaning we plan to support all smart contracts supported by the latest Ethereum hardfork version. But in the current version, something is incompatible with EVM.
 
+## EVM revision
+The maximum EVM revision supported is `EVMC_BERLIN`.
+- [ ] support EVMC_LONDON
+- [ ] support EVMC_SHANGHAI
+
 ## pETH
 
 **pETH** is a new concept introduced by Polyjuice.
 
-Recall that in Ethereum, the gas of each smart contract is calculated. The transaction fee is calculated then by multiplying gas with specified gas price. In Polyjuice, **pETH** is used as the unit for calculating transaction fees. This means while the gas price in Ethereum is ETH/gas(which is denominated in wei, which is 1e-18 ether), in Polyjuice gas price is measured in pETH/gas. When executing a transaction, Polyjuice will deduct transaction fees using tokens in the layer 2 sUDT type denoted by **pETH**.
+Recall that in Ethereum, the gas of each smart contract is calculated. The transaction fee is calculated then by multiplying gas with specified gas price. In Polyjuice, **pETH** is used as the unit for calculating transaction fees. This means while the gas price in Ethereum is ETH/gas(which is denominated in wei, which is 1e-18 ether), in Polyjuice gas price is measured in pETH/gas. When executing a transaction, Polyjuice will deduct transaction fees using tokens in the layer2 [sUDT](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0025-simple-udt/0025-simple-udt.md) type denoted by **pETH**.
 
 Note in Ethereum, one can also send some ETH to a smart contract for certain behavior. In Polyjuice, this feature is also performed by sending pETH.
 
 ## Account Abstraction
 
-Polyjuice only provides [contract accounts](https://ethereum.org/en/glossary/#contract-account). Godwoken's user accounts are leveraged to act as [EoAs](https://ethereum.org/en/glossary/#eoa).
+Polyjuice only provides [contract accounts](https://ethereum.org/en/glossary/#contract-account). Godwoken's user accounts are leveraged to act as [EOAs](https://ethereum.org/en/glossary/#eoa).
 
 ## Transaction Structure
 
 A Polyjuice transaction is essentially just a Godwoken transaction.
 
-When you send an ethereum transaction, the transaction is converted to Godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/9a3d92/crates/types/schemas/godwoken.mol#L56-L61) type which is automatically handled by [Polyjuice-Provider](https://github.com/nervosnetwork/polyjuice-provider).
+When you send an Ethereum transaction, the transaction is converted to Godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/9a3d92/crates/types/schemas/godwoken.mol#L56-L61) type which is automatically handled by [Godwoken Web3](https://github.com/nervosnetwork/godwoken-web3/tree/6e78293).
 
 ## Behavioral differences of some opcodes
 
@@ -30,13 +35,17 @@ When you send an ethereum transaction, the transaction is converted to Godwoken 
 
 ## Others
 
-* transaction context
+* Transaction context
   * `chain_id` consists up of two parts: [**compatible_chain_id(u32) | [creator_account_id]()(u32)**]
     - `compatible_chain_id` is defined in Godwoken [RollupConfig](https://github.com/nervosnetwork/godwoken/blob/acc6614/crates/types/schemas/godwoken.mol#L64).
     - `creator_account` is known as [the root account of Polyjuice](https://github.com/nervosnetwork/godwoken/blob/5735d8f/docs/life_of_a_polyjuice_transaction.md#root-account--deployment).
   * block gas limit is `12500000`, and is not block level limit, every transaction can reach the limit
   * block difficulty is always `2500000000000000`
+
+* Value (pETH) transfer from EOA to EOA directly is not supported.
+  > Workaround: Since pETH (CKB) is a layer2 sUDT, it could be transfered through the [sUDT_ERC20_Proxy](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract's `transfer function`.
 * The `transfer value` can not exceed uint128:MAX
-* pre-compiled contract
+
+* Pre-compiled contract
   * `bn256_pairing` is not supported yet，due to too high cycle cost (WIP)
   * [addition pre-compiled contracts](Addition-Features.md)

--- a/docs/EVM-compatible.md
+++ b/docs/EVM-compatible.md
@@ -43,7 +43,7 @@ When you send an Ethereum transaction, the transaction is converted to Godwoken 
   * block difficulty is always `2500000000000000`
 
 * Value (pETH) transfer from EOA to EOA directly is not supported.
-  > Workaround: Since pETH (CKB) is a layer2 sUDT, it could be transfered through the [sUDT_ERC20_Proxy](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract's `transfer function`.
+  > Workaround: pETH (CKB) is represented as an ERC 20 token on layer2, it could be transfer through the [sUDT_ERC20_Proxy](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract's `transfer function`.
 * The `transfer value` can not exceed uint128:MAX
 
 * Pre-compiled contract


### PR DESCRIPTION
## Docs
* Value (pETH) transfer from EOA to EOA directly is not supported.
  > Workaround: Since pETH (CKB) is a layer2 sUDT, it could be transfered through the [sUDT_ERC20_Proxy](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract's `transfer function`.
* The `transfer value` can not exceed uint128:MAX

## Related PR
- https://github.com/nervosnetwork/godwoken-web3/pull/207