### PR TITLE
chore(CI): remove kicker_ref in the inputs of reusable-integration-test-v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,3 @@ jobs:
       # github.head_ref: The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.
       # github.ref: The branch or tag ref that triggered the workflow run. For branches this is the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.
       polyjuice_ref: ${{ github.head_ref || github.ref }}
-      kicker_ref: refs/pull/179/head


### PR DESCRIPTION
~~delete kicker_ref: refs/pull/179/head~~