### PR TITLE
Fix address collision between contract and unused EOA

### DIFF
--- a/c/polyjuice.h
+++ b/c/polyjuice.h
@@ -704,8 +704,7 @@ void emit_log(struct evmc_host_context* context, const evmc_address* address,
 /**
  * check address collision
  * check existence of eth_addr
- * - if exists, then check nonce > 0 or it's NOT an EOA: return AddressCollision error
- * - else, we can overwrite addr mapping
+ * If it's an EoA address with non-zero nonce or it's an contract address, it can't be overwrite.
  * @param overwrite true if there is a collision but we can continue to create a new account
  * @return 0 means success
 */
@@ -737,7 +736,7 @@ int check_address_collision(gw_context_t* ctx, const uint8_t eth_addr[ETH_ADDRES
     return ret;
   }
   // check nonce and EOA
-  if (nonce > 0 || (ret == 0 && code_size > 0)) {
+  if (nonce > 0 || code_size > 0) {
     return ERROR_CONTRACT_ADDRESS_COLLISION;
   }
   // There is a collision. We can create a new account and re-map.

--- a/c/polyjuice.h
+++ b/c/polyjuice.h
@@ -742,6 +742,7 @@ int check_address_collision(gw_context_t* ctx, const uint8_t eth_addr[ETH_ADDRES
   }
   // There is a collision. We can create a new account and re-map.
   *overwrite = true;
+  
   ckb_debug("[address collision] continue and re-map");
   return 0;
 }

--- a/c/polyjuice.h
+++ b/c/polyjuice.h
@@ -713,8 +713,11 @@ int check_address_collision(gw_context_t* ctx, const uint8_t eth_addr[ETH_ADDRES
   gw_reg_addr_t addr = new_reg_addr(eth_addr);
   uint8_t script_hash[32] = {0};
   int ret = ctx->sys_get_script_hash_by_registry_address(ctx, &addr, script_hash);
-  if (ret != 0) {
+  if (ret == GW_ERROR_NOT_FOUND) {
     return 0;
+  }
+  if (ret != 0) {
+    return ret;
   }
   uint32_t account_id;
   ret = ctx->sys_get_account_id_by_script_hash(ctx, script_hash, &account_id);
@@ -724,9 +727,15 @@ int check_address_collision(gw_context_t* ctx, const uint8_t eth_addr[ETH_ADDRES
   // account exists
   uint32_t nonce;
   ret = ctx->sys_get_account_nonce(ctx, account_id, &nonce);
+  if (ret != 0) {
+    return ret;
+  }
   uint8_t code[MAX_DATA_SIZE];
   uint64_t code_size = MAX_DATA_SIZE;
   ret = load_account_code(ctx, account_id, &code_size, 0, code);
+  if (ret != 0) {
+    return ret;
+  }
   // check nonce and EOA
   if (nonce > 0 || (ret == 0 && code_size > 0)) {
     return ERROR_CONTRACT_ADDRESS_COLLISION;

--- a/c/polyjuice_errors.h
+++ b/c/polyjuice_errors.h
@@ -21,5 +21,6 @@
 #define ERROR_RECOVER_ACCOUNT                   -89
 
 #define ERROR_TOTAL_SUPPLY_OF_ANY_SUDT          -91
+#define ERROR_CONTRACT_ADDRESS_COLLISION	    -92
 
 #endif // POLYJUICE_ERRORS_H

--- a/c/polyjuice_globals.h
+++ b/c/polyjuice_globals.h
@@ -1,7 +1,7 @@
 #ifndef POLYJUICE_GLOBALS_H
 #define POLYJUICE_GLOBALS_H
 
-#define POLYJUICE_VERSION "v1.1.5-beta"
+#define POLYJUICE_VERSION "v1.1.6-beta"
 
 #define ETH_ADDRESS_LEN 20
 

--- a/polyjuice-tests/Cargo.lock
+++ b/polyjuice-tests/Cargo.lock
@@ -1427,6 +1427,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "polyjuice-tests"
 version = "1.1.5"
 dependencies = [
+ "anyhow",
  "ckb-vm",
  "env_logger",
  "gw-common",

--- a/polyjuice-tests/Cargo.toml
+++ b/polyjuice-tests/Cargo.toml
@@ -21,6 +21,7 @@ tiny-keccak = "1.4"
 rlp = "0.5.0"
 hex = "0.4.2"
 env_logger = "0.8.3"
+anyhow = "1.0"
 
 # ethabi = "^17.0.0"
 # rand = "0.7.3"

--- a/polyjuice-tests/src/test_cases/address_collision.rs
+++ b/polyjuice-tests/src/test_cases/address_collision.rs
@@ -1,0 +1,298 @@
+use std::convert::TryInto;
+
+use anyhow::Result;
+use ckb_vm::Bytes;
+use gw_common::{
+    builtins::ETH_REGISTRY_ACCOUNT_ID, registry_address::RegistryAddress, state::State,
+};
+use gw_generator::traits::StateExt;
+use gw_store::{chain_view::ChainView, traits::chain_store::ChainStore};
+use gw_types::{
+    packed::RawL2Transaction,
+    prelude::{Builder, Entity, Pack},
+};
+
+use crate::helper::{
+    create_block_producer, create_eth_eoa_account, deploy, new_block_info, setup, MockContractInfo,
+    PolyjuiceArgsBuilder, CREATOR_ACCOUNT_ID, L2TX_MAX_CYCLES,
+};
+
+const INIT_CODE: &str = include_str!("./evm-contracts/CreateContract.bin");
+const SS_CODE: &str = include_str!("./evm-contracts/SimpleStorage.bin");
+const CREATE2_IMPL_CODE: &str = include_str!("./evm-contracts/Create2Impl.bin");
+
+#[test]
+fn create_address_collision_overwrite() -> Result<()> {
+    let (store, mut state, generator) = setup();
+    let block_producer_id = create_block_producer(&mut state);
+
+    let from_eth_address = [1u8; 20];
+    let (from_id, _from_script_hash) =
+        create_eth_eoa_account(&mut state, &from_eth_address, 200000u64.into());
+
+    let create_eth_addr = hex::decode("808bfd2069b1ca619a55585e7b1ac1b11d392af9")?;
+    let create_eth_reg_addr =
+        RegistryAddress::new(ETH_REGISTRY_ACCOUNT_ID, create_eth_addr.clone());
+    //create EOA account with create_account address first
+    let (eoa_id, _) = create_eth_eoa_account(
+        &mut state,
+        &create_eth_addr.try_into().unwrap(),
+        200000u64.into(),
+    );
+
+    assert_eq!(eoa_id, 6);
+
+    let _ = deploy(
+        &generator,
+        &store,
+        &mut state,
+        CREATOR_ACCOUNT_ID,
+        from_id,
+        INIT_CODE,
+        122000,
+        0,
+        block_producer_id,
+        1,
+    );
+
+    let script_hash = state.get_script_hash_by_registry_address(&create_eth_reg_addr)?;
+    assert!(script_hash.is_some());
+    let create_account_id = state.get_account_id_by_script_hash(&script_hash.unwrap())?;
+    assert_eq!(create_account_id, Some(8));
+    Ok(())
+}
+
+#[test]
+#[should_panic(expected = "deploy Polyjuice contract")]
+fn create_address_collision_duplicate() {
+    let (store, mut state, generator) = setup();
+    let block_producer_id = create_block_producer(&mut state);
+
+    let from_eth_address = [1u8; 20];
+    let (from_id, _from_script_hash) =
+        create_eth_eoa_account(&mut state, &from_eth_address, 200000u64.into());
+
+    let create_eth_addr = hex::decode("808bfd2069b1ca619a55585e7b1ac1b11d392af9").unwrap();
+    let create_eth_reg_addr =
+        RegistryAddress::new(ETH_REGISTRY_ACCOUNT_ID, create_eth_addr.clone());
+    //create EOA account with create_account address first
+    let (eoa_id, _) = create_eth_eoa_account(
+        &mut state,
+        &create_eth_addr.try_into().unwrap(),
+        200000u64.into(),
+    );
+
+    assert_eq!(eoa_id, 6);
+
+    let _ = deploy(
+        &generator,
+        &store,
+        &mut state,
+        CREATOR_ACCOUNT_ID,
+        eoa_id,
+        SS_CODE,
+        122000,
+        0,
+        block_producer_id.clone(),
+        1,
+    );
+    let eoa_nonce = state.get_nonce(eoa_id);
+    assert_eq!(eoa_nonce, Ok(1));
+
+    let _ = deploy(
+        &generator,
+        &store,
+        &mut state,
+        CREATOR_ACCOUNT_ID,
+        from_id,
+        INIT_CODE,
+        122000,
+        0,
+        block_producer_id,
+        1,
+    );
+
+    let script_hash = state
+        .get_script_hash_by_registry_address(&create_eth_reg_addr)
+        .unwrap();
+    assert!(script_hash.is_some());
+    let create_account_id = state
+        .get_account_id_by_script_hash(&script_hash.unwrap())
+        .unwrap();
+    assert_eq!(create_account_id, Some(8));
+}
+
+#[test]
+fn create2_address_collision_overwrite() -> Result<()> {
+    let (store, mut state, generator) = setup();
+    let block_producer_id = create_block_producer(&mut state);
+
+    let from_eth_address = [1u8; 20];
+    let (from_id, _from_script_hash) =
+        create_eth_eoa_account(&mut state, &from_eth_address, 200000u64.into());
+
+    let create2_eth_addr = hex::decode("d78e81d86aeace84ff6311db7b134c1231a4a402")?;
+    let create2_eth_reg_addr =
+        RegistryAddress::new(ETH_REGISTRY_ACCOUNT_ID, create2_eth_addr.clone());
+    //create EOA account with create_account address first
+    let (eoa_id, _) = create_eth_eoa_account(
+        &mut state,
+        &create2_eth_addr.try_into().unwrap(),
+        200000u64.into(),
+    );
+
+    assert_eq!(eoa_id, 6);
+
+    let _ = deploy(
+        &generator,
+        &store,
+        &mut state,
+        CREATOR_ACCOUNT_ID,
+        from_id,
+        CREATE2_IMPL_CODE,
+        122000,
+        0,
+        block_producer_id.clone(),
+        1,
+    );
+
+    let create2_contract = MockContractInfo::create(&from_eth_address, 0);
+    let create2_contract_script_hash = create2_contract.script_hash;
+    let create2_contract_id = state
+        .get_account_id_by_script_hash(&create2_contract_script_hash)
+        .unwrap()
+        .unwrap();
+    let input_value_u128: u128 = 0x9a;
+    // bytes32 salt
+    let input_salt = "1111111111111111111111111111111111111111111111111111111111111111";
+    // Create2Impl.deploy(uint256 value, bytes32 salt, bytes memory code)
+    let block_number = 2;
+    let block_info = new_block_info(block_producer_id, block_number, block_number);
+    // uint256 value: 0x000000000000000000000000000000000000000000000000000000000000009a
+    let input_value = format!(
+        "00000000000000000000000000000000000000000000000000000000000000{:2x}",
+        input_value_u128
+    );
+    let input = hex::decode(format!("66cfa057{}{}00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000101{}00000000000000000000000000000000000000000000000000000000000000", input_value, input_salt, SS_CODE)).unwrap();
+
+    let args = PolyjuiceArgsBuilder::default()
+        .gas_limit(91000)
+        .gas_price(1)
+        .value(input_value_u128)
+        .input(&input)
+        .build();
+    let raw_tx = RawL2Transaction::new_builder()
+        .from_id(from_id.pack())
+        .to_id(create2_contract_id.pack())
+        .args(Bytes::from(args).pack())
+        .build();
+    let db = store.begin_transaction();
+    let tip_block_hash = db.get_tip_block_hash().unwrap();
+    let run_result = generator
+        .execute_transaction(
+            &ChainView::new(&db, tip_block_hash),
+            &state,
+            &block_info,
+            &raw_tx,
+            L2TX_MAX_CYCLES,
+            None,
+        )
+        .expect("Create2Impl.deploy(uint256 value, bytes32 salt, bytes memory code)");
+    state.apply_run_result(&run_result).expect("update state");
+
+    let script_hash = state.get_script_hash_by_registry_address(&create2_eth_reg_addr)?;
+    assert!(script_hash.is_some());
+    let create_account_id = state.get_account_id_by_script_hash(&script_hash.unwrap())?;
+    assert_eq!(create_account_id, Some(8));
+    Ok(())
+}
+
+#[test]
+fn create2_address_collision_duplicate() -> Result<()> {
+    let (store, mut state, generator) = setup();
+    let block_producer_id = create_block_producer(&mut state);
+
+    let from_eth_address = [1u8; 20];
+    let (from_id, _from_script_hash) =
+        create_eth_eoa_account(&mut state, &from_eth_address, 200000u64.into());
+
+    let create2_eth_addr = hex::decode("d78e81d86aeace84ff6311db7b134c1231a4a402")?;
+    //create EOA account with create_account address first
+    let (eoa_id, _) = create_eth_eoa_account(
+        &mut state,
+        &create2_eth_addr.try_into().unwrap(),
+        200000u64.into(),
+    );
+
+    assert_eq!(eoa_id, 6);
+    let _ = deploy(
+        &generator,
+        &store,
+        &mut state,
+        CREATOR_ACCOUNT_ID,
+        eoa_id,
+        SS_CODE,
+        122000,
+        0,
+        block_producer_id.clone(),
+        1,
+    );
+    let eoa_nonce = state.get_nonce(eoa_id);
+    assert_eq!(eoa_nonce, Ok(1));
+
+    let _ = deploy(
+        &generator,
+        &store,
+        &mut state,
+        CREATOR_ACCOUNT_ID,
+        from_id,
+        CREATE2_IMPL_CODE,
+        122000,
+        0,
+        block_producer_id.clone(),
+        1,
+    );
+
+    let create2_contract = MockContractInfo::create(&from_eth_address, 0);
+    let create2_contract_script_hash = create2_contract.script_hash;
+    let create2_contract_id = state
+        .get_account_id_by_script_hash(&create2_contract_script_hash)?
+        .unwrap();
+    let input_value_u128: u128 = 0x9a;
+    // bytes32 salt
+    let input_salt = "1111111111111111111111111111111111111111111111111111111111111111";
+    // Create2Impl.deploy(uint256 value, bytes32 salt, bytes memory code)
+    let block_number = 2;
+    let block_info = new_block_info(block_producer_id, block_number, block_number);
+    // uint256 value: 0x000000000000000000000000000000000000000000000000000000000000009a
+    let input_value = format!(
+        "00000000000000000000000000000000000000000000000000000000000000{:2x}",
+        input_value_u128
+    );
+    let input = hex::decode(format!("66cfa057{}{}00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000101{}00000000000000000000000000000000000000000000000000000000000000", input_value, input_salt, SS_CODE)).unwrap();
+
+    let args = PolyjuiceArgsBuilder::default()
+        .gas_limit(91000)
+        .gas_price(1)
+        .value(input_value_u128)
+        .input(&input)
+        .build();
+    let raw_tx = RawL2Transaction::new_builder()
+        .from_id(from_id.pack())
+        .to_id(create2_contract_id.pack())
+        .args(Bytes::from(args).pack())
+        .build();
+    let db = store.begin_transaction();
+    let tip_block_hash = db.get_tip_block_hash().unwrap();
+    let run_result = generator.execute_transaction(
+        &ChainView::new(&db, tip_block_hash),
+        &state,
+        &block_info,
+        &raw_tx,
+        L2TX_MAX_CYCLES,
+        None,
+    );
+    assert!(run_result.is_err());
+
+    Ok(())
+}

--- a/polyjuice-tests/src/test_cases/mod.rs
+++ b/polyjuice-tests/src/test_cases/mod.rs
@@ -24,11 +24,11 @@ pub(crate) mod pre_compiled_contracts;
 pub(crate) mod recover_account;
 pub(crate) mod rlp;
 //  Special pre-compiled contract to support transfer to any sudt
-pub(crate) mod address_collision;
 pub(crate) mod invalid_sudt_erc20_proxy;
 pub(crate) mod sudt_erc20_proxy;
 
 mod beacon_proxy;
 mod error;
+mod address_collision;
 mod eth_addr_reg;
 mod utils;

--- a/polyjuice-tests/src/test_cases/mod.rs
+++ b/polyjuice-tests/src/test_cases/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod pre_compiled_contracts;
 pub(crate) mod recover_account;
 pub(crate) mod rlp;
 //  Special pre-compiled contract to support transfer to any sudt
+pub(crate) mod address_collision;
 pub(crate) mod invalid_sudt_erc20_proxy;
 pub(crate) mod sudt_erc20_proxy;
 


### PR DESCRIPTION
Fix address collision between EOA account address and contract address created by `create`/`create2`.
We can overwrite the mapping if it's an EOA account and the nonce is 0.


- This PR depends on https://github.com/nervosnetwork/godwoken-scripts/pull/119