### PR TITLE
fix(testnet_v0): add `TESTNET_V0_FORK1`

### DIFF
--- a/c/polyjuice.h
+++ b/c/polyjuice.h
@@ -1104,7 +1104,9 @@ int handle_message(gw_context_t* ctx,
    * 2. CALLCODE/DELEGATECALL should skip `handle_transfer`, otherwise
    *    `value transfer` of CALLCODE/DELEGATECALL will be executed twice
    */
-  if (!is_special_call(msg.kind)) {
+  if (!is_special_call(msg.kind) || 
+     (g_chain_id == TESTNET_V0_CHAIN_ID &&
+      ctx->block_info.number < TESTNET_V0_FORK1_BLOCK)) {
     bool to_address_is_eoa = !to_address_exists
                           || (to_address_exists && code_size == 0);
     ret = handle_transfer(ctx, &msg, (uint8_t *)g_tx_origin.bytes,

--- a/c/polyjuice_globals.h
+++ b/c/polyjuice_globals.h
@@ -1,7 +1,7 @@
 #ifndef POLYJUICE_GLOBALS_H
 #define POLYJUICE_GLOBALS_H
 
-#define POLYJUICE_VERSION "v0.8.12"
+#define POLYJUICE_VERSION "v0.8.13"
 #define POLYJUICE_SHORT_ADDR_LEN 20
 /* 32 + 4 + 20 */
 #define SCRIPT_ARGS_LEN 56
@@ -15,5 +15,15 @@ static uint32_t g_creator_account_id = UINT32_MAX;
 static evmc_address g_tx_origin = {0};
 static uint8_t g_script_code_hash[32] = {0};
 static uint8_t g_script_hash_type = 0xff;
+
+/**
+ * @brief Hardforks
+ * 
+ * TESTNET_V0_FORK1
+ *   fix: CALLCODE and DELEGATECALL should skip transfer
+ *   https://github.com/nervosnetwork/godwoken-polyjuice/commit/c927fb6ce6d5c3632e09bc5de2d1485736c56fe0
+ */
+#define TESTNET_V0_CHAIN_ID     71393
+#define TESTNET_V0_FORK1_BLOCK 380000
 
 #endif // POLYJUICE_GLOBALS_H


### PR DESCRIPTION
Polyjuice [v0.8.12](https://github.com/nervosnetwork/godwoken-polyjuice/releases/tag/v0.8.12) has been updated on Godwoken mainnet_v0.
But this [commit](https://github.com/nervosnetwork/godwoken-polyjuice/commit/c927fb6ce6d5c3632e09bc5de2d1485736c56fe0) is not forward compatible on testnet_v0.

So, we need a simple hardfork mechanism to solve it.
This PR introduce TESTNET_V0_FORK1.
 