### PR TITLE
feat: reuse simplified godwoken-test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,37 @@ jobs:
 
 
   integration-test:
-    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
+    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@simplify-workflow
     with:
-      # github.ref: The branch or tag ref that triggered the workflow run. For branches this is the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.
-      polyjuice_ref: ${{ github.ref }}
-      tests_ref: develop  # https://github.com/nervosnetwork/godwoken-tests/commits/develop
-      kicker_ref: compatibility-changes # https://github.com/RetricSu/godwoken-kicker/commits/compatibility-changes
-      # gw_prebuild_image_name: <default value in docker/docker-compose.yml of kicker_ref>
-      # gw_prebuild_image_tag: <default value in docker/docker-compose.yml of kicker_ref>
+        # If you want to use a specified version of Godwoken, there are
+        # two approaches you can try:
+        #
+        # 1. Use kicker's manual-build mode directly
+        #
+        #    ```
+        #    with:
+        #      extra_github_env: |
+        #        MANUAL_BUILD_POLYJUICE=true
+        #        POLYJUICE_GIT_URL=https://github.com/${{ github.repository }}
+        #        POLYJUICE_GIT_CHECKOUT=${{ github.ref }}
+        #        MANUAL_BUILD_GODWOKEN=true
+        #        GODWOKEN_GIT_URL=https://github.com/<owner name>/godwoken
+        #        GODWOKEN_GIT_CHECKOUT=<repo ref>
+        #    ```
+        #
+        # 2. Use a specified version of Kicker
+        #
+        #    ```
+        #    with:
+        #      extra_github_env: |
+        #        MANUAL_BUILD_POLYJUICE=true
+        #        POLYJUICE_GIT_URL=https://github.com/${{ github.repository }}
+        #        POLYJUICE_GIT_CHECKOUT=${{ github.ref }}
+        #
+        #        GODWOKEN_KICKER_REPO=<kicker repo>
+        #        GODWOKEN_KICKER_REF=<kicker ref, you modified the godwoken image at this branch>
+        #    ```
+      extra_github_env: |
+        MANUAL_BUILD_POLYJUICE=true
+        POLYJUICE_GIT_URL=https://github.com/${{ github.repository }}
+        POLYJUICE_GIT_CHECKOUT=${{ github.ref }}


### PR DESCRIPTION
With this update, we can create PR from fork repos now.

The target godwoken-tests workflow: https://github.com/nervosnetwork/godwoken-tests/blob/simplify-workflow/.github/workflows/reusable-integration-test-v1.yml