### PR TITLE
test: handle logs hash in post of ethereum tests

### DIFF
--- a/polyjuice-tests/Cargo.lock
+++ b/polyjuice-tests/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "gw-ckb-hardfork"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "arc-swap",
  "ckb-types",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "gw-common"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "gw-hash",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "gw-config"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "ckb-fixed-hash",
  "gw-jsonrpc-types",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "gw-db"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "ckb-rocksdb",
  "gw-config",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "gw-generator"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1001,14 +1001,14 @@ dependencies = [
 
 [[package]]
 name = "gw-hash"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "blake2b-ref",
 ]
 
 [[package]]
 name = "gw-jsonrpc-types"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-fixed-hash",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "gw-rpc-client"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "gw-store"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "gw-traits"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "gw-common",
  "gw-db",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "gw-types"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "cfg-if 0.1.10",
  "ckb-fixed-hash",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "gw-utils"
-version = "1.4.0-rc4"
+version = "1.5.0-rc1"
 dependencies = [
  "anyhow",
  "ckb-crypto",


### PR DESCRIPTION
Add an assert to compare logs hash in VM test.


## Reference
**Generated State Transition Tests**
Contains transactions that are to be executed on a state pre given the environment env and must end up with post results post

**About log hash of the transaction logs in the `Post Section`**
https://ethereum-tests.readthedocs.io/en/latest/test_types/gstate_tests.html#post-section
