### PR TITLE
fix: g_gas_price constant is too large for its type

### DIFF
--- a/c/polyjuice_globals.h
+++ b/c/polyjuice_globals.h
@@ -38,7 +38,8 @@ static evmc_address g_tx_origin = {0};
 static uint8_t g_script_code_hash[32] = {0};
 static uint8_t g_script_hash_type = 0xff;
 
-static uint128_t g_gas_price = 0xffffffffffffffffffffffffffffffffu;
+#define UINT128_MAX uint128_t(__int128_t(-1L));
+static uint128_t g_gas_price = UINT128_MAX;
 
 /* Minimal gas of a normal transaction*/
 #define MIN_TX_GAS                      21000

--- a/devtools/ci/integration-test.sh
+++ b/devtools/ci/integration-test.sh
@@ -23,7 +23,8 @@ else
     git clone --depth=1 https://github.com/ethereum/tests.git $ETHEREUM_TEST_DIR
 fi
 cd $GODWOKEN_DIR
-git fetch origin develop
+# checkout https://github.com/nervosnetwork/godwoken/commits/v1.5.0-rc2
+git fetch origin v1.5.0-rc2
 git checkout FETCH_HEAD 
 git submodule update --init --recursive --depth=1
 


### PR DESCRIPTION
GCC interpretes literal constants as 64 bits integers.

> warning: integer constant is too large for its type static uint128_t g_gas_price = 0xffffffffffffffffffffffffffffffffu;

=>
```js
UINT128_MAX = uint128_t(__int128_t(-1L))
= 340282366920938463463374607431768211455
= 0xffffffffffffffffffffffffffffffffu
```